### PR TITLE
Fix firewall rule toggle confirmation dialog text

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -990,6 +990,26 @@
       }
     }
   },
+  "disableRuleConfirmation": "هل أنت متأكد من أنك تريد تعطيل القاعدة \"{description}\"؟",
+  "@disableRuleConfirmation": {
+    "description": "Translation for disableRuleConfirmation",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "192.168.1.1"
+      }
+    }
+  },
+  "enableRuleConfirmation": "هل أنت متأكد من أنك تريد تفعيل القاعدة \"{description}\"؟",
+  "@enableRuleConfirmation": {
+    "description": "Translation for enableRuleConfirmation",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "192.168.1.1"
+      }
+    }
+  },
   "deleteServerConfirmation": "هل أنت متأكد من حذف الخادم \"{name}\"؟ لا يمكن التراجع عن هذا الإجراء.",
   "@deleteServerConfirmation": {
     "description": "Translation for deleteServerConfirmation",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -988,6 +988,26 @@
       }
     }
   },
+  "disableRuleConfirmation": "Sind Sie sicher, dass Sie die Regel \"{description}\" deaktivieren möchten?",
+  "@disableRuleConfirmation": {
+    "description": "Translation for disableRuleConfirmation",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "192.168.1.1"
+      }
+    }
+  },
+  "enableRuleConfirmation": "Sind Sie sicher, dass Sie die Regel \"{description}\" aktivieren möchten?",
+  "@enableRuleConfirmation": {
+    "description": "Translation for enableRuleConfirmation",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "192.168.1.1"
+      }
+    }
+  },
   "deleteServerConfirmation": "Möchten Sie den Server \"{name}\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
   "@deleteServerConfirmation": {
     "description": "Translation for deleteServerConfirmation",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -961,6 +961,22 @@
       }
     }
   },
+  "disableRuleConfirmation": "Are you sure you want to disable the rule \"{description}\"?",
+  "@disableRuleConfirmation": {
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "enableRuleConfirmation": "Are you sure you want to enable the rule \"{description}\"?",
+  "@enableRuleConfirmation": {
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
   "deleteServerConfirmation": "Are you sure you want to delete server \"{name}\"? This action cannot be undone.",
   "@deleteServerConfirmation": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -988,6 +988,26 @@
       }
     }
   },
+  "disableRuleConfirmation": "¿Está seguro de que desea deshabilitar la regla \"{description}\"?",
+  "@disableRuleConfirmation": {
+    "description": "Translation for disableRuleConfirmation",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "192.168.1.1"
+      }
+    }
+  },
+  "enableRuleConfirmation": "¿Está seguro de que desea habilitar la regla \"{description}\"?",
+  "@enableRuleConfirmation": {
+    "description": "Translation for enableRuleConfirmation",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "192.168.1.1"
+      }
+    }
+  },
   "deleteServerConfirmation": "¿Está seguro de que desea eliminar el servidor \"{name}\"? Esta acción no se puede deshacer.",
   "@deleteServerConfirmation": {
     "description": "Translation for deleteServerConfirmation",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -988,6 +988,26 @@
       }
     }
   },
+  "disableRuleConfirmation": "Êtes-vous sûr de vouloir désactiver la règle \"{description}\" ?",
+  "@disableRuleConfirmation": {
+    "description": "Translation for disableRuleConfirmation",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "192.168.1.1"
+      }
+    }
+  },
+  "enableRuleConfirmation": "Êtes-vous sûr de vouloir activer la règle \"{description}\" ?",
+  "@enableRuleConfirmation": {
+    "description": "Translation for enableRuleConfirmation",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "192.168.1.1"
+      }
+    }
+  },
   "deleteServerConfirmation": "Êtes-vous sûr de vouloir supprimer le serveur \"{name}\" ? Cette action ne peut pas être annulée.",
   "@deleteServerConfirmation": {
     "description": "Translation for deleteServerConfirmation",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1376,6 +1376,18 @@ abstract class AppLocalizations {
   /// **'Are you sure you want to delete the rule \"{description}\"?'**
   String deleteRuleConfirmation(String description);
 
+  /// No description provided for @disableRuleConfirmation.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to disable the rule \"{description}\"?'**
+  String disableRuleConfirmation(String description);
+
+  /// No description provided for @enableRuleConfirmation.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to enable the rule \"{description}\"?'**
+  String enableRuleConfirmation(String description);
+
   /// No description provided for @deleteServerConfirmation.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -714,6 +714,16 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String disableRuleConfirmation(String description) {
+    return 'هل أنت متأكد من أنك تريد تعطيل القاعدة \"$description\"؟';
+  }
+
+  @override
+  String enableRuleConfirmation(String description) {
+    return 'هل أنت متأكد من أنك تريد تفعيل القاعدة \"$description\"؟';
+  }
+
+  @override
   String deleteServerConfirmation(String name) {
     return 'هل أنت متأكد من حذف الخادم \"$name\"؟ لا يمكن التراجع عن هذا الإجراء.';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -734,6 +734,16 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String disableRuleConfirmation(String description) {
+    return 'Sind Sie sicher, dass Sie die Regel \"$description\" deaktivieren möchten?';
+  }
+
+  @override
+  String enableRuleConfirmation(String description) {
+    return 'Sind Sie sicher, dass Sie die Regel \"$description\" aktivieren möchten?';
+  }
+
+  @override
   String deleteServerConfirmation(String name) {
     return 'Möchten Sie den Server \"$name\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -721,6 +721,16 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String disableRuleConfirmation(String description) {
+    return 'Are you sure you want to disable the rule \"$description\"?';
+  }
+
+  @override
+  String enableRuleConfirmation(String description) {
+    return 'Are you sure you want to enable the rule \"$description\"?';
+  }
+
+  @override
   String deleteServerConfirmation(String name) {
     return 'Are you sure you want to delete server \"$name\"? This action cannot be undone.';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -730,6 +730,16 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String disableRuleConfirmation(String description) {
+    return '¿Está seguro de que desea deshabilitar la regla \"$description\"?';
+  }
+
+  @override
+  String enableRuleConfirmation(String description) {
+    return '¿Está seguro de que desea habilitar la regla \"$description\"?';
+  }
+
+  @override
   String deleteServerConfirmation(String name) {
     return '¿Está seguro de que desea eliminar el servidor \"$name\"? Esta acción no se puede deshacer.';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -730,6 +730,16 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String disableRuleConfirmation(String description) {
+    return 'Êtes-vous sûr de vouloir désactiver la règle \"$description\" ?';
+  }
+
+  @override
+  String enableRuleConfirmation(String description) {
+    return 'Êtes-vous sûr de vouloir activer la règle \"$description\" ?';
+  }
+
+  @override
   String deleteServerConfirmation(String name) {
     return 'Êtes-vous sûr de vouloir supprimer le serveur \"$name\" ? Cette action ne peut pas être annulée.';
   }

--- a/lib/screens/firewall_rules_screen.dart
+++ b/lib/screens/firewall_rules_screen.dart
@@ -131,7 +131,9 @@ class _FirewallRulesScreenState extends State<FirewallRulesScreen> {
       builder: (context) => AlertDialog(
         title: Text(actionTitle),
         content: Text(
-          l10n.deleteRuleConfirmation(rule.description.isEmpty ? l10n.unnamedRule : rule.description),
+          rule.isEnabled
+            ? l10n.disableRuleConfirmation(rule.description.isEmpty ? l10n.unnamedRule : rule.description)
+            : l10n.enableRuleConfirmation(rule.description.isEmpty ? l10n.unnamedRule : rule.description),
         ),
         actions: [
           TextButton(


### PR DESCRIPTION
## Summary
Fixes issue #30 - Corrects the confirmation dialog text when enabling/disabling firewall rules. Previously, the dialog incorrectly used "delete" terminology when toggling rules on/off.

## Changes Made
- Added new localization strings `disableRuleConfirmation` and `enableRuleConfirmation` in all supported languages (en, ar, de, es, fr)
- Updated [`firewall_rules_screen.dart`](lib/screens/firewall_rules_screen.dart:134) to use the correct confirmation message based on the rule's current state:
  - Shows "disable" confirmation when rule is enabled
  - Shows "enable" confirmation when rule is disabled
- Generated corresponding localization files for all languages

## Testing
- Verify that enabling a disabled rule shows "Are you sure you want to enable..." message
- Verify that disabling an enabled rule shows "Are you sure you want to disable..." message
- Confirm translations are correct in all supported languages

## Related Issue
Closes #30