### PR TITLE
Fix WireGuard status page type mismatch error

### DIFF
--- a/lib/models/wireguard_status.dart
+++ b/lib/models/wireguard_status.dart
@@ -51,13 +51,13 @@ class WireGuardStatusItem {
   /// Name/description (may be empty)
   final String? name;
   
-  /// Latest handshake age in human-readable format (e.g., "2 minutes ago")
+  /// Latest handshake age in seconds (numeric value or null)
   @JsonKey(name: 'latest-handshake-age')
-  final String? latestHandshakeAge;
+  final int? latestHandshakeAge;
   
-  /// Latest handshake epoch timestamp
+  /// Latest handshake epoch as formatted date string (e.g., "2026-06-06 12:53:56")
   @JsonKey(name: 'latest-handshake-epoch')
-  final int? latestHandshakeEpoch;
+  final String? latestHandshakeEpoch;
   
   /// Peer status: "online" or "offline"
   @JsonKey(name: 'peer-status')
@@ -99,7 +99,12 @@ class WireGuardStatusItem {
   /// Get latest handshake as DateTime (null if not available)
   DateTime? get latestHandshakeDateTime {
     if (latestHandshakeEpoch == null) return null;
-    return DateTime.fromMillisecondsSinceEpoch(latestHandshakeEpoch! * 1000);
+    try {
+      // Parse the date string format: "2026-06-06 12:53:56"
+      return DateTime.parse(latestHandshakeEpoch!.replaceFirst(' ', 'T'));
+    } catch (e) {
+      return null;
+    }
   }
   
   /// Check if public key is set (not "(none)")

--- a/lib/models/wireguard_status.g.dart
+++ b/lib/models/wireguard_status.g.dart
@@ -16,8 +16,8 @@ WireGuardStatusItem _$WireGuardStatusItemFromJson(Map<String, dynamic> json) =>
       endpoint: json['endpoint'] as String,
       status: json['status'] as String,
       name: json['name'] as String?,
-      latestHandshakeAge: json['latest-handshake-age'] as String?,
-      latestHandshakeEpoch: (json['latest-handshake-epoch'] as num?)?.toInt(),
+      latestHandshakeAge: (json['latest-handshake-age'] as num?)?.toInt(),
+      latestHandshakeEpoch: json['latest-handshake-epoch'] as String?,
       peerStatus: json['peer-status'] as String,
       ifname: json['ifname'] as String,
     );

--- a/lib/services/demo/demo_vpn_data_generator.dart
+++ b/lib/services/demo/demo_vpn_data_generator.dart
@@ -401,7 +401,6 @@ f70f5dd3g5b11f0d2c4f9d6e8g3b2c5d
 
   /// Generate demo WireGuard status response
   WireGuardStatusResponse generateWireGuardStatusResponse() {
-    final now = DateTime.now();
     final items = [
       WireGuardStatusItem(
         interfaceName: 'wg0',
@@ -426,8 +425,8 @@ f70f5dd3g5b11f0d2c4f9d6e8g3b2c5d
         endpoint: '203.0.113.50:41234',
         status: 'up',
         name: 'Mobile Device',
-        latestHandshakeAge: '2 minutes ago',
-        latestHandshakeEpoch: (now.millisecondsSinceEpoch ~/ 1000) - 120,
+        latestHandshakeAge: 120,
+        latestHandshakeEpoch: DateTime.now().subtract(const Duration(seconds: 120)).toString().substring(0, 19).replaceFirst('T', ' '),
         peerStatus: 'online',
         ifname: 'wg0',
       ),
@@ -440,8 +439,8 @@ f70f5dd3g5b11f0d2c4f9d6e8g3b2c5d
         endpoint: '198.51.100.75:52341',
         status: 'up',
         name: 'Laptop',
-        latestHandshakeAge: '45 seconds ago',
-        latestHandshakeEpoch: (now.millisecondsSinceEpoch ~/ 1000) - 45,
+        latestHandshakeAge: 45,
+        latestHandshakeEpoch: DateTime.now().subtract(const Duration(seconds: 45)).toString().substring(0, 19).replaceFirst('T', ' '),
         peerStatus: 'online',
         ifname: 'wg0',
       ),

--- a/lib/widgets/wireguard/status_card.dart
+++ b/lib/widgets/wireguard/status_card.dart
@@ -148,7 +148,7 @@ class StatusCard extends StatelessWidget {
               _buildInfoRow(
                 context,
                 'Handshake Age',
-                item.latestHandshakeAge!,
+                '${item.latestHandshakeAge!} seconds ago',
                 icon: Icons.access_time,
               ),
             


### PR DESCRIPTION
## Description
Fixes issue #32 where the WireGuard status page fails to load with a type error: `type 'Null' is not a subtype of type 'String'`.

## Problem
The WireGuard status API response format changed:
- `latest-handshake-age` is now returned as an integer (seconds) instead of a human-readable string
- `latest-handshake-epoch` is now returned as a formatted date string instead of an epoch timestamp integer

This caused type mismatches in the model parsing, resulting in the status page failing to load.

## Solution
Updated the [`WireGuardStatusItem`](lib/models/wireguard_status.dart) model to match the actual API response format:
- Changed `latestHandshakeAge` from `String?` to `int?` (now represents seconds)
- Changed `latestHandshakeEpoch` from `int?` to `String?` (now represents formatted date string)
- Updated `latestHandshakeDateTime` getter to parse the date string format instead of converting from epoch
- Updated the UI display in [`StatusCard`](lib/widgets/wireguard/status_card.dart) to format the seconds value
- Updated demo data generator to match the new format

## Changes
- `lib/models/wireguard_status.dart` - Updated field types and parsing logic
- `lib/models/wireguard_status.g.dart` - Regenerated JSON serialization code
- `lib/services/demo/demo_vpn_data_generator.dart` - Updated demo data to match new format
- `lib/widgets/wireguard/status_card.dart` - Updated UI to display handshake age correctly

## Testing
- [x] WireGuard status page loads without errors
- [x] Handshake age displays correctly
- [x] Demo mode works with updated data format