### PR TITLE
Fix: Kea DHCP server support and profile management improvements

### DIFF
--- a/lib/screens/settings/profile_management_screen.dart
+++ b/lib/screens/settings/profile_management_screen.dart
@@ -332,6 +332,10 @@ class _ProfileManagementScreenState extends State<ProfileManagementScreen> {
     required bool allowSelfSignedCerts,
     required DhcpServerType dhcpServerType,
   }) async {
+    // Get the API services from context
+    final demoApiService = context.read<DemoApiService>();
+    final opnsenseApiService = context.read<OPNsenseApiService>();
+    
     final result = await _profileManager.saveProfile(
       id: id,
       name: name,
@@ -341,6 +345,9 @@ class _ProfileManagementScreenState extends State<ProfileManagementScreen> {
       useHttps: useHttps,
       allowSelfSignedCerts: allowSelfSignedCerts,
       dhcpServerType: dhcpServerType,
+      context: context,
+      demoApiService: demoApiService,
+      opnsenseApiService: opnsenseApiService,
     );
 
     if (result.success) {

--- a/lib/services/dhcp_lease_adapter.dart
+++ b/lib/services/dhcp_lease_adapter.dart
@@ -122,17 +122,24 @@ class DhcpLeaseAdapter {
     // Normalize KEA DHCP field names to match our model
     return rawLeases.map((lease) {
       return {
-        'address': lease['ip-address'] ?? lease['address'] ?? '',
-        'hostname': lease['hostname'] ?? lease['fqdn-fwd'] ?? 'unknown',
-        'hwaddr': lease['hw-address'] ?? lease['hwaddr'] ?? lease['mac'] ?? '',
-        'mac_info': lease['mac_info'] ?? lease['vendor-class-data'],
+        'address': _safeToString(lease['ip-address'] ?? lease['address']),
+        'hostname': _safeToString(lease['hostname'] ?? lease['fqdn-fwd']) ?? 'unknown',
+        'hwaddr': _safeToString(lease['hw-address'] ?? lease['hwaddr'] ?? lease['mac']),
+        'mac_info': _safeToString(lease['mac_info'] ?? lease['vendor-class-data']),
         'starts': _parseKeaTime(lease['cltt']),
-        'ends': _parseKeaTime(lease['valid-lft'], lease['cltt']),
-        'expire': _parseKeaTime(lease['valid-lft'], lease['cltt']),
-        'state': lease['state'] ?? 'active',
+        'ends': _parseKeaTime(lease['valid-lft'] ?? lease['valid_lifetime'], lease['cltt']),
+        'expire': _parseKeaTime(lease['expire'] ?? lease['valid-lft'] ?? lease['valid_lifetime'], lease['cltt']),
+        'state': _safeToString(lease['state']) ?? 'active',
         'cltt': _parseKeaTime(lease['cltt']),
-        'if': lease['subnet-id']?.toString(),
-        'type': lease['type'] ?? 'dynamic',
+        'if': _safeToString(lease['subnet-id'] ?? lease['if']),
+        'if_descr': _safeToString(lease['if_descr']),
+        'if_name': _safeToString(lease['if_name']),
+        'type': _safeToString(lease['type']) ?? 'dynamic',
+        'prefix_len': _safeToString(lease['prefix_len']),
+        'duid': _safeToString(lease['duid']),
+        'client_id': _safeToString(lease['client_id']),
+        'iaid': _safeToString(lease['iaid']),
+        'is_reserved': lease['is_reserved'],
       };
     }).toList();
   }
@@ -191,5 +198,15 @@ class DhcpLeaseAdapter {
     }
     
     return null;
+  }
+
+  /// Safely convert a value to String, handling both int and String types
+  /// Returns null if the value is null or empty string
+  static String? _safeToString(dynamic value) {
+    if (value == null) return null;
+    if (value is String) {
+      return value.isEmpty ? null : value;
+    }
+    return value.toString();
   }
 }

--- a/lib/services/network/dhcp_service.dart
+++ b/lib/services/network/dhcp_service.dart
@@ -20,6 +20,7 @@ import 'package:dio/dio.dart';
 import '../base/base_opnsense_service.dart';
 import '../base/api_exception.dart';
 import '../dhcp_lease_adapter.dart';
+import '../../models/dhcp_server_type.dart';
 
 /// Service for DHCP operations
 class DHCPService extends BaseOPNsenseService {
@@ -30,8 +31,23 @@ class DHCPService extends BaseOPNsenseService {
     final serverType = config.dhcpServerType;
     
     try {
-      // Use the appropriate API endpoint for the server type
-      final response = await dio.get(serverType.apiEndpoint);
+      // Kea DHCP requires POST with payload, others use GET
+      final Response response;
+      if (serverType == DhcpServerType.kea) {
+        // Kea DHCP requires POST with search parameters
+        response = await dio.post(
+          serverType.apiEndpoint,
+          data: {
+            'current': 1,
+            'rowCount': 50,
+            'sort': {},
+            'selected_interfaces': [],
+          },
+        );
+      } else {
+        // dnsmasq and ISC DHCP use GET requests
+        response = await dio.get(serverType.apiEndpoint);
+      }
       
       if (response.statusCode == 200) {
         final data = response.data;

--- a/lib/services/settings/profile_manager_service.dart
+++ b/lib/services/settings/profile_manager_service.dart
@@ -116,7 +116,8 @@ class ProfileManagerService {
 
   /// Save a profile (create or update)
   ///
-  /// Validates the profile data and saves it to storage
+  /// Validates the profile data and saves it to storage.
+  /// If the saved profile is the active one, re-initializes API services.
   Future<SaveResult> saveProfile({
     String? id,
     required String name,
@@ -126,6 +127,9 @@ class ProfileManagerService {
     required bool useHttps,
     required bool allowSelfSignedCerts,
     required DhcpServerType dhcpServerType,
+    BuildContext? context,
+    DemoApiService? demoApiService,
+    OPNsenseApiService? opnsenseApiService,
   }) async {
     try {
       // Get active connection for validation
@@ -180,6 +184,29 @@ class ProfileManagerService {
 
       await _profileService.saveProfile(profile);
 
+      // Check if this is the active profile and re-initialize if needed
+      final activeProfileId = await _profileService.getActiveProfileId();
+      if (profile.id == activeProfileId &&
+          context != null &&
+          demoApiService != null &&
+          opnsenseApiService != null) {
+        // Re-initialize by activating the updated profile
+        final activationResult = await activateProfile(
+          context: context,
+          profile: profile,
+          demoApiService: demoApiService,
+          opnsenseApiService: opnsenseApiService,
+        );
+        
+        // If activation fails, return the error
+        if (!activationResult.success) {
+          return SaveResult(
+            success: false,
+            errorMessage: 'Profile saved but failed to re-initialize: ${activationResult.errorMessage}',
+          );
+        }
+      }
+
       return SaveResult(
         success: true,
         profile: profile,
@@ -225,6 +252,7 @@ extension ProfileExtension on Profile {
       apiSecret: apiSecret,
       useHttps: useHttps,
       allowSelfSignedCerts: allowSelfSignedCerts,
+      dhcpServerType: dhcpServerType,
     );
   }
 }


### PR DESCRIPTION
## Summary
Fixes issue #28 - Kea DHCP not working properly. This PR addresses multiple issues with Kea DHCP server integration and improves profile management functionality.

## Changes Made

### DHCP Service Improvements
- **Fixed Kea DHCP API calls**: Changed from GET to POST requests with proper payload structure for Kea DHCP server
- **Enhanced lease data normalization**: Added `_safeToString()` helper to handle mixed data types (int/String) from different DHCP servers
- **Improved field mapping**: Added support for additional Kea-specific fields including:
  - `valid_lifetime` as fallback for `valid-lft`
  - `if_descr`, `if_name` for interface descriptions
  - `prefix_len`, `duid`, `client_id`, `iaid` for DHCPv6 support
  - `is_reserved` flag for reserved leases

### Profile Management Enhancements
- **Auto-reinitialization**: When editing the active profile, API services are now automatically re-initialized with updated settings
- **Fixed missing DHCP server type**: Added `dhcpServerType` parameter to profile conversion extension
- **Improved error handling**: Better error messages when profile activation fails after save

## Files Changed
- [`lib/services/network/dhcp_service.dart`](lib/services/network/dhcp_service.dart) - Fixed Kea DHCP API endpoint usage
- [`lib/services/dhcp_lease_adapter.dart`](lib/services/dhcp_lease_adapter.dart) - Enhanced data normalization and field mapping
- [`lib/services/settings/profile_manager_service.dart`](lib/services/settings/profile_manager_service.dart) - Added auto-reinitialization for active profiles
- [`lib/screens/settings/profile_management_screen.dart`](lib/screens/settings/profile_management_screen.dart) - Pass API services to profile manager

## Testing
- [x] Tested with Kea DHCP server
- [x] Verified profile editing and auto-reinitialization
- [x] Confirmed backward compatibility with ISC DHCP and dnsmasq

## Related Issues
Closes #28