### PR TITLE
Fix Kea DHCP static leases incorrectly showing as dynamic

### DIFF
--- a/lib/services/dhcp_lease_adapter.dart
+++ b/lib/services/dhcp_lease_adapter.dart
@@ -134,7 +134,7 @@ class DhcpLeaseAdapter {
         'if': _safeToString(lease['subnet-id'] ?? lease['if']),
         'if_descr': _safeToString(lease['if_descr']),
         'if_name': _safeToString(lease['if_name']),
-        'type': _safeToString(lease['type']) ?? 'dynamic',
+        'type': (lease['is_reserved'] is List && (lease['is_reserved'] as List).isNotEmpty) ? 'static' : 'dynamic',
         'prefix_len': _safeToString(lease['prefix_len']),
         'duid': _safeToString(lease['duid']),
         'client_id': _safeToString(lease['client_id']),


### PR DESCRIPTION
## Summary

Fixed bug where Kea DHCP static leases were incorrectly displayed as dynamic leases.

## Changes

- Updated DHCP lease type detection in dhcp_lease_adapter.dart
- Changed type determination logic to check is_reserved field instead of relying on type field
- Static leases now correctly identified when is_reserved list is non-empty

## Technical Details

The fix changes the type assignment from:
```dart
'type': _safeToString(lease['type']) ?? 'dynamic',
```

To:
```dart
'type': (lease['is_reserved'] is List && (lease['is_reserved'] as List).isNotEmpty) ? 'static' : 'dynamic',
```

This properly detects Kea DHCP reservations by checking the is_reserved field rather than the type field which was not being set correctly by the Kea DHCP server.