### PR TITLE
Add thermal sensors to dashboard

### DIFF
--- a/lib/models/firewall_alias.g.dart
+++ b/lib/models/firewall_alias.g.dart
@@ -18,6 +18,7 @@ FirewallAlias _$FirewallAliasFromJson(Map<String, dynamic> json) =>
       proto: json['proto'] as String? ?? '',
       interface: json['interface'] as String? ?? '',
       categories: json['categories'] as String? ?? '',
+      currentItems: json['current_items'] as String? ?? '0',
     );
 
 Map<String, dynamic> _$FirewallAliasToJson(FirewallAlias instance) =>
@@ -32,6 +33,7 @@ Map<String, dynamic> _$FirewallAliasToJson(FirewallAlias instance) =>
       'proto': instance.proto,
       'interface': instance.interface,
       'categories': instance.categories,
+      'current_items': instance.currentItems,
     };
 
 FirewallAliasRequest _$FirewallAliasRequestFromJson(

--- a/lib/models/thermal_sensor.dart
+++ b/lib/models/thermal_sensor.dart
@@ -1,0 +1,79 @@
+/*
+ * OPNsense Manager - Flutter application for managing OPNsense firewalls
+ * Copyright (C) 2026 OPNsense Manager
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'thermal_sensor.g.dart';
+
+/// Represents a thermal sensor reading from OPNsense system
+@JsonSerializable()
+class ThermalSensor {
+  /// Device name/identifier
+  final String device;
+  
+  /// Device sequence number
+  final int deviceSeq;
+  
+  /// Temperature reading as string (e.g., "45.0C")
+  final String temperature;
+  
+  /// Translated sensor type description
+  final String typeTranslated;
+  
+  /// Sensor type identifier
+  final String type;
+
+  ThermalSensor({
+    required this.device,
+    required this.deviceSeq,
+    required this.temperature,
+    required this.typeTranslated,
+    required this.type,
+  });
+
+  /// Get temperature value as a double (removes 'C' suffix and parses)
+  double get temperatureValue {
+    // Remove 'C' suffix and any whitespace, then parse
+    final tempStr = temperature.replaceAll(RegExp(r'[^\d.-]'), '');
+    return double.tryParse(tempStr) ?? 0.0;
+  }
+
+  /// Create from JSON
+  factory ThermalSensor.fromJson(Map<String, dynamic> json) =>
+      _$ThermalSensorFromJson(json);
+
+  /// Convert to JSON
+  Map<String, dynamic> toJson() => _$ThermalSensorToJson(this);
+
+  @override
+  String toString() =>
+      'ThermalSensor(device: $device, temperature: $temperature, type: $typeTranslated)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ThermalSensor &&
+        other.device == device &&
+        other.deviceSeq == deviceSeq;
+  }
+
+  @override
+  int get hashCode => Object.hash(device, deviceSeq);
+}
+
+// Made with Bob

--- a/lib/models/thermal_sensor.dart
+++ b/lib/models/thermal_sensor.dart
@@ -27,12 +27,14 @@ class ThermalSensor {
   final String device;
   
   /// Device sequence number
+  @JsonKey(name: 'device_seq')
   final int deviceSeq;
   
   /// Temperature reading as string (e.g., "45.0C")
   final String temperature;
   
   /// Translated sensor type description
+  @JsonKey(name: 'type_translated')
   final String typeTranslated;
   
   /// Sensor type identifier

--- a/lib/models/thermal_sensor.dart
+++ b/lib/models/thermal_sensor.dart
@@ -76,4 +76,4 @@ class ThermalSensor {
   int get hashCode => Object.hash(device, deviceSeq);
 }
 
-// Made with Bob
+

--- a/lib/models/thermal_sensor.g.dart
+++ b/lib/models/thermal_sensor.g.dart
@@ -9,17 +9,17 @@ part of 'thermal_sensor.dart';
 ThermalSensor _$ThermalSensorFromJson(Map<String, dynamic> json) =>
     ThermalSensor(
       device: json['device'] as String,
-      deviceSeq: (json['deviceSeq'] as num).toInt(),
+      deviceSeq: (json['device_seq'] as num).toInt(),
       temperature: json['temperature'] as String,
-      typeTranslated: json['typeTranslated'] as String,
+      typeTranslated: json['type_translated'] as String,
       type: json['type'] as String,
     );
 
 Map<String, dynamic> _$ThermalSensorToJson(ThermalSensor instance) =>
     <String, dynamic>{
       'device': instance.device,
-      'deviceSeq': instance.deviceSeq,
+      'device_seq': instance.deviceSeq,
       'temperature': instance.temperature,
-      'typeTranslated': instance.typeTranslated,
+      'type_translated': instance.typeTranslated,
       'type': instance.type,
     };

--- a/lib/models/thermal_sensor.g.dart
+++ b/lib/models/thermal_sensor.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'thermal_sensor.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ThermalSensor _$ThermalSensorFromJson(Map<String, dynamic> json) =>
+    ThermalSensor(
+      device: json['device'] as String,
+      deviceSeq: (json['deviceSeq'] as num).toInt(),
+      temperature: json['temperature'] as String,
+      typeTranslated: json['typeTranslated'] as String,
+      type: json['type'] as String,
+    );
+
+Map<String, dynamic> _$ThermalSensorToJson(ThermalSensor instance) =>
+    <String, dynamic>{
+      'device': instance.device,
+      'deviceSeq': instance.deviceSeq,
+      'temperature': instance.temperature,
+      'typeTranslated': instance.typeTranslated,
+      'type': instance.type,
+    };

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/system_info.dart';
+import '../models/thermal_sensor.dart';
 import '../services/demo_api_service.dart';
 import '../services/opnsense_api_service.dart';
 import '../services/profile_service.dart';
@@ -30,6 +31,7 @@ import '../widgets/app_drawer.dart';
 import '../widgets/dashboard/resource_usage_section.dart';
 import '../widgets/dashboard/services_section.dart';
 import '../widgets/dashboard/gateways_section.dart';
+import '../widgets/dashboard/thermal_sensors_section.dart';
 import '../l10n/app_localizations.dart';
 
 /// Main dashboard screen showing system overview
@@ -44,6 +46,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   SystemInfo? _systemInfo;
   Map<String, dynamic> _servicesData = {};
   List<Map<String, dynamic>> _gateways = [];
+  List<ThermalSensor>? _thermalSensors;
   bool _isLoading = true;
   String? _errorMessage;
   Timer? _refreshTimer;
@@ -107,6 +110,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
           _systemInfo = dashboardData.systemInfo;
           _servicesData = dashboardData.servicesData;
           _gateways = dashboardData.gateways;
+          _thermalSensors = dashboardData.thermalSensors;
           _isLoading = false;
         });
       }
@@ -282,6 +286,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
         if (_systemInfo != null)
           ResourceUsageSection(systemInfo: _systemInfo!),
         const SizedBox(height: 24),
+        
+        // Thermal Sensors Section
+        if (_thermalSensors != null)
+          ThermalSensorsSection(sensors: _thermalSensors!),
+        if (_thermalSensors != null)
+          const SizedBox(height: 24),
         
         // Services Section
         ServicesSection(

--- a/lib/services/dashboard/dashboard_data_loader.dart
+++ b/lib/services/dashboard/dashboard_data_loader.dart
@@ -84,7 +84,10 @@ class DashboardDataLoader {
     try {
       final sensors = await _apiService.getSystemTemperature();
       return sensors;
-    } catch (e) {
+    } catch (e, stackTrace) {
+      // Log error for debugging
+      print('Error loading thermal sensors: $e');
+      print('Stack trace: $stackTrace');
       // Return null on error to distinguish from empty array (VM case)
       return null;
     }

--- a/lib/services/dashboard/dashboard_data_loader.dart
+++ b/lib/services/dashboard/dashboard_data_loader.dart
@@ -17,6 +17,7 @@
  */
 
 import '../../models/system_info.dart';
+import '../../models/thermal_sensor.dart';
 import '../demo_api_service.dart';
 
 /// Data class for dashboard data
@@ -24,11 +25,13 @@ class DashboardData {
   final SystemInfo systemInfo;
   final Map<String, dynamic> servicesData;
   final List<Map<String, dynamic>> gateways;
+  final List<ThermalSensor>? thermalSensors;
 
   DashboardData({
     required this.systemInfo,
     required this.servicesData,
     required this.gateways,
+    this.thermalSensors,
   });
 }
 
@@ -44,12 +47,14 @@ class DashboardDataLoader {
       _apiService.getSystemInfo(),
       _loadServices(),
       _loadGateways(),
+      _loadThermalSensors(),
     ]);
 
     return DashboardData(
       systemInfo: results[0] as SystemInfo,
       servicesData: results[1] as Map<String, dynamic>,
       gateways: results[2] as List<Map<String, dynamic>>,
+      thermalSensors: results[3] as List<ThermalSensor>?,
     );
   }
 
@@ -70,6 +75,18 @@ class DashboardDataLoader {
       return gateways.cast<Map<String, dynamic>>();
     } catch (e) {
       return [];
+    }
+  }
+
+  /// Load thermal sensors data
+  /// Returns null if fetch fails, empty list if no sensors available (VM case)
+  Future<List<ThermalSensor>?> _loadThermalSensors() async {
+    try {
+      final sensors = await _apiService.getSystemTemperature();
+      return sensors;
+    } catch (e) {
+      // Return null on error to distinguish from empty array (VM case)
+      return null;
     }
   }
 }

--- a/lib/services/demo/demo_system_data_generator.dart
+++ b/lib/services/demo/demo_system_data_generator.dart
@@ -18,6 +18,7 @@
 
 import 'dart:math';
 import '../../models/system_info.dart';
+import '../../models/thermal_sensor.dart';
 import 'demo_state_manager.dart';
 
 /// Generator for system-related demo data
@@ -120,6 +121,47 @@ class DemoSystemDataGenerator {
         'stddev': '${2 + _random.nextInt(4)}ms',
         'loss': '0%',
       },
+    ];
+  }
+
+  /// Generate demo thermal sensors with realistic temperatures
+  List<ThermalSensor> generateThermalSensors() {
+    return [
+      ThermalSensor(
+        device: 'cpu0',
+        deviceSeq: 0,
+        temperature: '${45 + _random.nextInt(15)}.0C',
+        typeTranslated: 'CPU Core 0',
+        type: 'cpu',
+      ),
+      ThermalSensor(
+        device: 'cpu1',
+        deviceSeq: 1,
+        temperature: '${45 + _random.nextInt(15)}.0C',
+        typeTranslated: 'CPU Core 1',
+        type: 'cpu',
+      ),
+      ThermalSensor(
+        device: 'cpu2',
+        deviceSeq: 2,
+        temperature: '${45 + _random.nextInt(15)}.0C',
+        typeTranslated: 'CPU Core 2',
+        type: 'cpu',
+      ),
+      ThermalSensor(
+        device: 'cpu3',
+        deviceSeq: 3,
+        temperature: '${45 + _random.nextInt(15)}.0C',
+        typeTranslated: 'CPU Core 3',
+        type: 'cpu',
+      ),
+      ThermalSensor(
+        device: 'acpitz0',
+        deviceSeq: 0,
+        temperature: '${40 + _random.nextInt(10)}.0C',
+        typeTranslated: 'Thermal Zone 0',
+        type: 'zone',
+      ),
     ];
   }
 }

--- a/lib/services/demo_api_service.dart
+++ b/lib/services/demo_api_service.dart
@@ -19,6 +19,7 @@
 export 'network/vip_service.dart' show CarpVipOption;
 
 import '../models/system_info.dart';
+import '../models/thermal_sensor.dart';
 import '../models/firewall_rule.dart';
 import '../models/firewall_alias.dart';
 import '../models/vpn_connection.dart';
@@ -75,6 +76,14 @@ class DemoApiService {
         isDemoMode: _isDemoMode,
         demoAction: () async => _demoDataService.generateSystemInfo(),
         realAction: () => _realApiService.getSystemInfo(),
+      );
+
+  /// Get system temperature sensors
+  Future<List<ThermalSensor>> getSystemTemperature() => DemoApiDecorator.execute(
+        isDemoMode: _isDemoMode,
+        demoAction: () async => _demoDataService.generateThermalSensors(),
+        realAction: () => _realApiService.getSystemTemperature(),
+        delayMs: 300,
       );
 
   /// Get firewall rules

--- a/lib/services/demo_data_service.dart
+++ b/lib/services/demo_data_service.dart
@@ -17,6 +17,7 @@
  */
 
 import '../models/system_info.dart';
+import '../models/thermal_sensor.dart';
 import '../models/firewall_rule.dart';
 import '../models/firewall_alias.dart';
 import '../models/vpn_connection.dart';
@@ -72,6 +73,9 @@ class DemoDataService {
 
   /// Generate demo gateways
   List<Map<String, dynamic>> generateGateways() => _systemGenerator.generateGateways();
+
+  /// Generate demo thermal sensors
+  List<ThermalSensor> generateThermalSensors() => _systemGenerator.generateThermalSensors();
 
   // ==================== Firewall Data ====================
 

--- a/lib/services/opnsense_api_service.dart
+++ b/lib/services/opnsense_api_service.dart
@@ -21,6 +21,7 @@ import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import '../models/opnsense_config.dart';
 import '../models/system_info.dart';
+import '../models/thermal_sensor.dart';
 import '../models/firewall_rule.dart';
 import '../models/firewall_alias.dart';
 import '../models/vpn_connection.dart';
@@ -210,6 +211,8 @@ class OPNsenseApiService {
   Future<Map<String, dynamic>> getSystemResources() => _systemService.getSystemResources();
   
   Future<SystemInfo> getSystemInfo() => _systemService.getSystemInfo();
+  
+  Future<List<ThermalSensor>> getSystemTemperature() => _systemService.getSystemTemperature();
   
   Future<void> rebootSystem() => _systemService.rebootSystem();
 

--- a/lib/services/system/system_service.dart
+++ b/lib/services/system/system_service.dart
@@ -20,6 +20,7 @@ import 'package:dio/dio.dart';
 import '../base/base_opnsense_service.dart';
 import '../base/api_exception.dart';
 import '../../models/system_info.dart';
+import '../../models/thermal_sensor.dart';
 
 /// Service for system-related operations
 class SystemService extends BaseOPNsenseService {
@@ -372,6 +373,39 @@ class SystemService extends BaseOPNsenseService {
     } catch (_) {
       // Silently handle error
       rethrow;
+    }
+  }
+
+  /// Get system temperature sensors
+  /// Returns a list of thermal sensors or an empty list for VM systems
+  Future<List<ThermalSensor>> getSystemTemperature() async {
+    ensureInitialized();
+
+    try {
+      final response = await dio.get('/diagnostics/system/system_temperature');
+      
+      if (response.statusCode == 200) {
+        final data = response.data;
+        
+        // Handle empty array response (common for VM systems without thermal sensors)
+        if (data is List) {
+          if (data.isEmpty) {
+            return [];
+          }
+          
+          // Parse list of thermal sensors
+          return data
+              .map((json) => ThermalSensor.fromJson(json as Map<String, dynamic>))
+              .toList();
+        }
+        
+        // If response is not a list, return empty list
+        return [];
+      } else {
+        throw ApiException('Failed to get system temperature', response.statusCode);
+      }
+    } on DioException catch (e) {
+      throw handleDioError(e);
     }
   }
 

--- a/lib/services/system/system_service.dart
+++ b/lib/services/system/system_service.dart
@@ -394,17 +394,30 @@ class SystemService extends BaseOPNsenseService {
           }
           
           // Parse list of thermal sensors
-          return data
-              .map((json) => ThermalSensor.fromJson(json as Map<String, dynamic>))
-              .toList();
+          try {
+            return data
+                .map((json) => ThermalSensor.fromJson(json as Map<String, dynamic>))
+                .toList();
+          } catch (e, stackTrace) {
+            print('Error parsing thermal sensor data: $e');
+            print('Raw data: $data');
+            print('Stack trace: $stackTrace');
+            rethrow;
+          }
         }
         
         // If response is not a list, return empty list
+        print('Warning: Thermal sensor response is not a list: ${data.runtimeType}');
         return [];
       } else {
         throw ApiException('Failed to get system temperature', response.statusCode);
       }
     } on DioException catch (e) {
+      print('DioException getting thermal sensors: ${e.message}');
+      if (e.response != null) {
+        print('Response status: ${e.response?.statusCode}');
+        print('Response data: ${e.response?.data}');
+      }
       throw handleDioError(e);
     }
   }

--- a/lib/widgets/dashboard/thermal_sensors_section.dart
+++ b/lib/widgets/dashboard/thermal_sensors_section.dart
@@ -1,0 +1,210 @@
+/*
+ * OPNsense Manager - Flutter application for managing OPNsense firewalls
+ * Copyright (C) 2026 OPNsense Manager
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter/material.dart';
+
+import '../../models/thermal_sensor.dart';
+
+/// Widget for displaying thermal sensor readings in a compact format.
+class ThermalSensorsSection extends StatelessWidget {
+  final List<ThermalSensor> sensors;
+
+  const ThermalSensorsSection({
+    super.key,
+    required this.sensors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Thermal Sensors',
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 12),
+            if (sensors.isEmpty)
+              Text(
+                'No thermal sensors available',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Colors.grey[600],
+                    ),
+              )
+            else
+              _buildCompactSensorList(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCompactSensorList(BuildContext context) {
+    final groupedSensors = _groupSensors(sensors);
+    final orderedSensors = [
+      ...groupedSensors['cpu'] ?? const <ThermalSensor>[],
+      ...groupedSensors['zone'] ?? const <ThermalSensor>[],
+      ...groupedSensors.entries
+          .where((entry) => entry.key != 'cpu' && entry.key != 'zone')
+          .expand((entry) => entry.value),
+    ];
+
+    return Column(
+      children: orderedSensors.asMap().entries.map((entry) {
+        final index = entry.key;
+        final sensor = entry.value;
+        final isLast = index == orderedSensors.length - 1;
+        
+        return Column(
+          children: [
+            _CompactSensorRow(sensor: sensor),
+            if (!isLast)
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: Colors.grey[200],
+              ),
+          ],
+        );
+      }).toList(),
+    );
+  }
+
+  Map<String, List<ThermalSensor>> _groupSensors(List<ThermalSensor> sensors) {
+    final grouped = <String, List<ThermalSensor>>{};
+
+    for (final sensor in sensors) {
+      final key = sensor.type.trim().toLowerCase();
+      grouped.putIfAbsent(key, () => []).add(sensor);
+    }
+
+    for (final entry in grouped.entries) {
+      entry.value.sort((a, b) {
+        final seqCompare = a.deviceSeq.compareTo(b.deviceSeq);
+        if (seqCompare != 0) {
+          return seqCompare;
+        }
+
+        return a.device.compareTo(b.device);
+      });
+    }
+
+    return grouped;
+  }
+}
+
+/// Compact row widget for displaying a single thermal sensor.
+class _CompactSensorRow extends StatelessWidget {
+  final ThermalSensor sensor;
+
+  const _CompactSensorRow({required this.sensor});
+
+  @override
+  Widget build(BuildContext context) {
+    final temperature = sensor.temperatureValue;
+    final color = _getTemperatureColor(temperature);
+    final sensorName = _safeText(sensor.typeTranslated, fallback: 'Unknown');
+    final deviceName = _safeText(sensor.device, fallback: 'Unknown device');
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 4),
+      child: Row(
+        children: [
+          // Icon with color background
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              Icons.thermostat,
+              color: color,
+              size: 20,
+            ),
+          ),
+          const SizedBox(width: 12),
+          // Sensor name and device
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  sensorName,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  deviceName,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.grey[600],
+                      ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          // Temperature value
+          Text(
+            '${temperature.toStringAsFixed(1)}°C',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: color,
+                ),
+          ),
+          const SizedBox(width: 8),
+          // Color indicator dot
+          Container(
+            width: 10,
+            height: 10,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getTemperatureColor(double temperature) {
+    if (temperature > 80) {
+      return Colors.red;
+    }
+    if (temperature >= 60) {
+      return Colors.orange;
+    }
+    return Colors.green;
+  }
+
+  String _safeText(String value, {required String fallback}) {
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? fallback : trimmed;
+  }
+}
+
+// Made with Bob

--- a/lib/widgets/dashboard/thermal_sensors_section.dart
+++ b/lib/widgets/dashboard/thermal_sensors_section.dart
@@ -207,4 +207,4 @@ class _CompactSensorRow extends StatelessWidget {
   }
 }
 
-// Made with Bob
+

--- a/test/models/thermal_sensor_test.dart
+++ b/test/models/thermal_sensor_test.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opnsense_manager/models/thermal_sensor.dart';
+
+void main() {
+  group('ThermalSensor', () {
+    test('parses actual API response correctly', () {
+      // Actual API response from user
+      const jsonString = '''
+      [
+        {
+          "device": "dev.cpu.0.temperature",
+          "device_seq": 0,
+          "temperature": "48.0",
+          "type_translated": "CPU",
+          "type": "cpu"
+        },
+        {
+          "device": "hw.acpi.thermal.tz0.temperature",
+          "device_seq": 0,
+          "temperature": "26.9",
+          "type_translated": "Zone",
+          "type": "zone"
+        }
+      ]
+      ''';
+
+      final List<dynamic> jsonList = json.decode(jsonString);
+      final sensors = jsonList
+          .map((json) => ThermalSensor.fromJson(json as Map<String, dynamic>))
+          .toList();
+
+      // Verify we got 2 sensors
+      expect(sensors.length, 2);
+
+      // Verify first sensor (CPU)
+      final cpuSensor = sensors[0];
+      expect(cpuSensor.device, 'dev.cpu.0.temperature');
+      expect(cpuSensor.deviceSeq, 0);
+      expect(cpuSensor.temperature, '48.0');
+      expect(cpuSensor.typeTranslated, 'CPU');
+      expect(cpuSensor.type, 'cpu');
+      expect(cpuSensor.temperatureValue, 48.0);
+
+      // Verify second sensor (Zone)
+      final zoneSensor = sensors[1];
+      expect(zoneSensor.device, 'hw.acpi.thermal.tz0.temperature');
+      expect(zoneSensor.deviceSeq, 0);
+      expect(zoneSensor.temperature, '26.9');
+      expect(zoneSensor.typeTranslated, 'Zone');
+      expect(zoneSensor.type, 'zone');
+      expect(zoneSensor.temperatureValue, 26.9);
+    });
+
+    test('temperatureValue getter handles plain numbers without °C suffix', () {
+      final sensor = ThermalSensor(
+        device: 'test.device',
+        deviceSeq: 0,
+        temperature: '48.0',
+        typeTranslated: 'Test',
+        type: 'test',
+      );
+
+      expect(sensor.temperatureValue, 48.0);
+    });
+
+    test('temperatureValue getter handles decimal values', () {
+      final sensor = ThermalSensor(
+        device: 'test.device',
+        deviceSeq: 0,
+        temperature: '26.9',
+        typeTranslated: 'Test',
+        type: 'test',
+      );
+
+      expect(sensor.temperatureValue, 26.9);
+    });
+
+    test('temperatureValue getter handles values with C suffix (legacy)', () {
+      final sensor = ThermalSensor(
+        device: 'test.device',
+        deviceSeq: 0,
+        temperature: '45.0C',
+        typeTranslated: 'Test',
+        type: 'test',
+      );
+
+      expect(sensor.temperatureValue, 45.0);
+    });
+
+    test('temperatureValue getter handles values with °C suffix (legacy)', () {
+      final sensor = ThermalSensor(
+        device: 'test.device',
+        deviceSeq: 0,
+        temperature: '45.0°C',
+        typeTranslated: 'Test',
+        type: 'test',
+      );
+
+      expect(sensor.temperatureValue, 45.0);
+    });
+
+    test('temperatureValue getter handles empty string', () {
+      final sensor = ThermalSensor(
+        device: 'test.device',
+        deviceSeq: 0,
+        temperature: '',
+        typeTranslated: 'Test',
+        type: 'test',
+      );
+
+      expect(sensor.temperatureValue, 0.0);
+    });
+
+    test('temperatureValue getter handles invalid format', () {
+      final sensor = ThermalSensor(
+        device: 'test.device',
+        deviceSeq: 0,
+        temperature: 'invalid',
+        typeTranslated: 'Test',
+        type: 'test',
+      );
+
+      expect(sensor.temperatureValue, 0.0);
+    });
+
+    test('toJson produces correct format', () {
+      final sensor = ThermalSensor(
+        device: 'dev.cpu.0.temperature',
+        deviceSeq: 0,
+        temperature: '48.0',
+        typeTranslated: 'CPU',
+        type: 'cpu',
+      );
+
+      final json = sensor.toJson();
+
+      expect(json['device'], 'dev.cpu.0.temperature');
+      expect(json['device_seq'], 0);
+      expect(json['temperature'], '48.0');
+      expect(json['type_translated'], 'CPU');
+      expect(json['type'], 'cpu');
+    });
+
+    test('equality works correctly', () {
+      final sensor1 = ThermalSensor(
+        device: 'dev.cpu.0.temperature',
+        deviceSeq: 0,
+        temperature: '48.0',
+        typeTranslated: 'CPU',
+        type: 'cpu',
+      );
+
+      final sensor2 = ThermalSensor(
+        device: 'dev.cpu.0.temperature',
+        deviceSeq: 0,
+        temperature: '50.0', // Different temperature
+        typeTranslated: 'CPU',
+        type: 'cpu',
+      );
+
+      final sensor3 = ThermalSensor(
+        device: 'dev.cpu.1.temperature', // Different device
+        deviceSeq: 1,
+        temperature: '48.0',
+        typeTranslated: 'CPU',
+        type: 'cpu',
+      );
+
+      expect(sensor1, sensor2); // Same device and deviceSeq
+      expect(sensor1, isNot(sensor3)); // Different device
+    });
+  });
+}
+
+// Made with Bob


### PR DESCRIPTION
## Summary

Adds thermal sensor monitoring to the dashboard, displaying CPU and thermal zone temperatures with real-time updates.

## Changes

- Added `ThermalSensor` model with JSON serialization and temperature parsing
- Added `ThermalSensorsSection` widget for dashboard display with temperature indicators
- Integrated thermal sensor data loading in `DashboardDataLoader`
- Added `fetchThermalSensors()` method to `SystemService` for API integration
- Added demo data generation for thermal sensors in demo mode
- Added comprehensive unit tests for `ThermalSensor` model (9 test cases)
- Updated dashboard screen to include thermal sensors section