### PR TITLE
Add F-Droid product flavor with ABI-specific builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to OPNsense Manager will be documented in this file.
 
+## [1.7.1] - 
+
+### Changed
+- Adjusted gradle file to include an fdroid flavor to support fdroid builds.
 
 ## [1.7.0] - 
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.util.Properties
 import java.io.FileInputStream
+import com.android.build.gradle.internal.api.ApkVariantOutputImpl
 
 plugins {
     id("com.android.application")
@@ -39,6 +40,19 @@ android {
         versionName = flutter.versionName
     }
 
+    flavorDimensions += "distribution"
+    
+    productFlavors {
+        create("playstore") {
+            dimension = "distribution"
+            isDefault = true
+        }
+        
+        create("fdroid") {
+            dimension = "distribution"
+        }
+    }
+
     signingConfigs {
         create("release") {
             if (keystorePropertiesFile.exists()) {
@@ -59,4 +73,22 @@ android {
 
 flutter {
     source = "../.."
+}
+
+
+// Apply ABI version code logic ONLY for F-Droid flavor
+val abiCodes = mapOf("armeabi-v7a" to 1, "arm64-v8a" to 2, "x86_64" to 3)
+
+android.applicationVariants.configureEach {
+    val variant = this
+    
+    // Only apply ABI version code override for fdroid flavor
+    if (variant.flavorName == "fdroid") {
+        variant.outputs.forEach { output ->
+            val abiVersionCode = abiCodes[output.filters.find { it.filterType == "ABI" }?.identifier]
+            if (abiVersionCode != null) {
+                (output as ApkVariantOutputImpl).versionCodeOverride = variant.versionCode * 10 + abiVersionCode
+            }
+        }
+    }
 }

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -23,7 +23,7 @@ import 'package:flutter/material.dart';
 class AppConstants {
   // App Information
   static const String appName = 'OPNsense Manager';
-  static const String appVersion = '1.7.0';
+  static const String appVersion = '1.7.1';
   
   // API Configuration
   static const int defaultPort = 443;

--- a/metadata/com.dt.opnsense_manager.yml
+++ b/metadata/com.dt.opnsense_manager.yml
@@ -1,6 +1,5 @@
 Categories:
-  - Internet
-  - System
+  - Firewall
 License: GPL-3.0-only
 AuthorName: Etregin
 AuthorWebSite: https://github.com/Etregin
@@ -14,31 +13,82 @@ Repo: https://github.com/Etregin/OPNsense_Manager
 
 Builds:
   - versionName: 1.7.0
-    versionCode: 12
+    versionCode: 121
     commit: 5eba00b1f4660a67dfa45c01df59deeef1746d7b
-    sudo:
-      - apt-get update
-      - apt-get install -y openjdk-21-jdk-headless
-      - update-alternatives --auto java
-    output: build/app/outputs/flutter-apk/app-release.apk
+    output: build/app/outputs/flutter-apk/app-armeabi-v7a-fdroid-release.apk
     srclibs:
-      - flutter@3.44.0
+      - flutter@stable
     rm:
       - ios
+      - linux
+      - macos
+      - web
+      - windows
     prebuild:
       - export PUB_CACHE=$(pwd)/.pub-cache
       - sed -i '/org.gradle.java.home/d' android/gradle.properties
-      - echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> android/gradle.properties
       - $$flutter$$/bin/flutter config --no-analytics
-      - $$flutter$$/bin/flutter pub get
+      - $$flutter$$/bin/flutter pub get --enforce-lockfile
     scandelete:
       - .pub-cache
     build:
       - export PUB_CACHE=$(pwd)/.pub-cache
-      - $$flutter$$/bin/flutter build apk
+      - $$flutter$$/bin/flutter build apk --split-per-abi --flavor fdroid --target-platform android-arm
+
+  - versionName: 1.7.0
+    versionCode: 122
+    commit: 5eba00b1f4660a67dfa45c01df59deeef1746d7b
+    output: build/app/outputs/flutter-apk/app-arm64-v8a-fdroid-release.apk
+    srclibs:
+      - flutter@stable
+    rm:
+      - ios
+      - linux
+      - macos
+      - web
+      - windows
+    prebuild:
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - sed -i '/org.gradle.java.home/d' android/gradle.properties
+      - $$flutter$$/bin/flutter config --no-analytics
+      - $$flutter$$/bin/flutter pub get --enforce-lockfile
+    scandelete:
+      - .pub-cache
+    build:
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter build apk --split-per-abi --flavor fdroid --target-platform android-arm64
+
+  - versionName: 1.7.0
+    versionCode: 123
+    commit: 5eba00b1f4660a67dfa45c01df59deeef1746d7b
+    output: build/app/outputs/flutter-apk/app-x86_64-fdroid-release.apk
+    srclibs:
+      - flutter@stable
+    rm:
+      - ios
+      - linux
+      - macos
+      - web
+      - windows
+    prebuild:
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - sed -i '/org.gradle.java.home/d' android/gradle.properties
+      - $$flutter$$/bin/flutter config --no-analytics
+      - $$flutter$$/bin/flutter pub get --enforce-lockfile
+    scandelete:
+      - .pub-cache
+    build:
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter build apk --split-per-abi --flavor fdroid --target-platform android-x64
+
+AllowedAPKSigningKeys: ca889bba23ca5c486a642ce077bcc5764ebf7194ef9e3cf99fd70c3eecf6a4b2
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
+VercodeOperation:
+  - '%c * 10 + 1'
+  - '%c * 10 + 2'
+  - '%c * 10 + 3'
 UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
 CurrentVersion: 1.7.0
-CurrentVersionCode: 12
+CurrentVersionCode: 123

--- a/metadata/com.dt.opnsense_manager.yml
+++ b/metadata/com.dt.opnsense_manager.yml
@@ -12,8 +12,8 @@ RepoType: git
 Repo: https://github.com/Etregin/OPNsense_Manager
 
 Builds:
-  - versionName: 1.7.0
-    versionCode: 121
+  - versionName: 1.7.1
+    versionCode: 131
     commit: 5eba00b1f4660a67dfa45c01df59deeef1746d7b
     output: build/app/outputs/flutter-apk/app-armeabi-v7a-fdroid-release.apk
     srclibs:
@@ -35,8 +35,8 @@ Builds:
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter build apk --split-per-abi --flavor fdroid --target-platform android-arm
 
-  - versionName: 1.7.0
-    versionCode: 122
+  - versionName: 1.7.1
+    versionCode: 132
     commit: 5eba00b1f4660a67dfa45c01df59deeef1746d7b
     output: build/app/outputs/flutter-apk/app-arm64-v8a-fdroid-release.apk
     srclibs:
@@ -58,8 +58,8 @@ Builds:
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter build apk --split-per-abi --flavor fdroid --target-platform android-arm64
 
-  - versionName: 1.7.0
-    versionCode: 123
+  - versionName: 1.7.1
+    versionCode: 133
     commit: 5eba00b1f4660a67dfa45c01df59deeef1746d7b
     output: build/app/outputs/flutter-apk/app-x86_64-fdroid-release.apk
     srclibs:
@@ -90,5 +90,5 @@ VercodeOperation:
   - '%c * 10 + 2'
   - '%c * 10 + 3'
 UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
-CurrentVersion: 1.7.0
-CurrentVersionCode: 123
+CurrentVersion: 1.7.1
+CurrentVersionCode: 133

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: opnsense_manager
 description: "OPNsense Manager - A professional Flutter mobile application for managing OPNsense firewall routers."
 publish_to: 'none'
 
-version: 1.7.0+12
+version: 1.7.1+13
 
 environment:
   sdk: '>=3.12.0 <4.0.0'


### PR DESCRIPTION
## Summary

Adds F-Droid product flavor configuration with ABI-specific build support for optimized APK distribution on F-Droid.

## Changes

- Added `fdroid` product flavor in `android/app/build.gradle.kts` alongside existing `playstore` flavor
- Configured ABI version code logic for F-Droid builds (armeabi-v7a, arm64-v8a, x86_64)
- Updated F-Droid metadata (`metadata/com.dt.opnsense_manager.yml`) with three separate build configurations for each ABI
- Changed F-Droid category from Internet/System to Firewall
- Updated app version to 1.7.1 in `lib/utils/constants.dart` and `pubspec.yaml`
- Added changelog entry for F-Droid flavor support