### PR TITLE
Fix misplaced refresh button on neighbor discovery screen

### DIFF
--- a/lib/screens/neighbor_discovery_screen.dart
+++ b/lib/screens/neighbor_discovery_screen.dart
@@ -599,11 +599,6 @@ class _NeighborDiscoveryScreenState extends State<NeighborDiscoveryScreen> {
                   onRetry: _loadNeighbors,
                 )
               : _buildContent(),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _isLoading ? null : _loadNeighbors,
-        tooltip: 'Refresh',
-        child: const Icon(Icons.refresh),
-      ),
     );
   }
 }


### PR DESCRIPTION
## Summary

Removes the incorrectly placed floating action button from the neighbor discovery screen.

## Changes

- Removed misplaced `FloatingActionButton` (refresh) from `lib/screens/neighbor_discovery_screen.dart`