### PR TITLE
Fix WireGuard status model fields to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to OPNsense Manager will be documented in this file.
 ### Fixed
 
 - Removed the incorrectly placed floating refresh button from the neighbor discovery screen.
+- Resolved an issue with Wiregaurd status field to make string fields nullable
 
 ## [1.7.2] -
 

--- a/lib/models/wireguard_status.dart
+++ b/lib/models/wireguard_status.dart
@@ -26,27 +26,27 @@ part 'wireguard_status.g.dart';
 class WireGuardStatusItem {
   /// Interface name (e.g., "wg0")
   @JsonKey(name: 'if')
-  final String interfaceName;
+  final String? interfaceName;
   
   /// Type: "interface" or "peer"
-  final String type;
+  final String? type;
   
   /// Public key (may be "(none)" for interfaces without keys)
   @JsonKey(name: 'public-key')
-  final String publicKey;
+  final String? publicKey;
   
-  /// Listen port for the interface
+  /// Listen port for the interface (only present on "interface" rows, not peers)
   @JsonKey(name: 'listen-port')
-  final String listenPort;
+  final String? listenPort;
   
-  /// Firewall mark setting
-  final String fwmark;
+  /// Firewall mark setting (only present on "interface" rows, not peers)
+  final String? fwmark;
   
   /// Endpoint (same as listen-port for interfaces)
-  final String endpoint;
+  final String? endpoint;
   
-  /// Status: "up" or "down"
-  final String status;
+  /// Status: "up" or "down" (only present on "interface" rows, not peers)
+  final String? status;
   
   /// Name/description (may be empty)
   final String? name;
@@ -61,40 +61,40 @@ class WireGuardStatusItem {
   
   /// Peer status: "online" or "offline"
   @JsonKey(name: 'peer-status')
-  final String peerStatus;
+  final String? peerStatus;
   
   /// Interface friendly name
-  final String ifname;
+  final String? ifname;
 
   WireGuardStatusItem({
-    required this.interfaceName,
-    required this.type,
-    required this.publicKey,
-    required this.listenPort,
-    required this.fwmark,
-    required this.endpoint,
-    required this.status,
+    this.interfaceName,
+    this.type,
+    this.publicKey,
+    this.listenPort,
+    this.fwmark,
+    this.endpoint,
+    this.status,
     this.name,
     this.latestHandshakeAge,
     this.latestHandshakeEpoch,
-    required this.peerStatus,
-    required this.ifname,
+    this.peerStatus,
+    this.ifname,
   });
 
   /// Check if the interface/peer is up
-  bool get isUp => status.toLowerCase() == 'up';
+  bool get isUp => status?.toLowerCase() == 'up';
   
   /// Check if this is an interface (not a peer)
-  bool get isInterface => type.toLowerCase() == 'interface';
+  bool get isInterface => type?.toLowerCase() == 'interface';
   
   /// Check if this is a peer
-  bool get isPeer => type.toLowerCase() == 'peer';
+  bool get isPeer => type?.toLowerCase() == 'peer';
   
   /// Check if peer is online
-  bool get isOnline => peerStatus.toLowerCase() == 'online';
+  bool get isOnline => peerStatus?.toLowerCase() == 'online';
   
   /// Get listen port as integer
-  int get listenPortNumber => int.tryParse(listenPort) ?? 0;
+  int get listenPortNumber => int.tryParse(listenPort ?? '') ?? 0;
   
   /// Get latest handshake as DateTime (null if not available)
   DateTime? get latestHandshakeDateTime {
@@ -108,7 +108,7 @@ class WireGuardStatusItem {
   }
   
   /// Check if public key is set (not "(none)")
-  bool get hasPublicKey => publicKey != '(none)' && publicKey.isNotEmpty;
+  bool get hasPublicKey => publicKey != null && publicKey != '(none)' && publicKey!.isNotEmpty;
 
   factory WireGuardStatusItem.fromJson(Map<String, dynamic> json) =>
       _$WireGuardStatusItemFromJson(json);

--- a/lib/models/wireguard_status.g.dart
+++ b/lib/models/wireguard_status.g.dart
@@ -8,18 +8,18 @@ part of 'wireguard_status.dart';
 
 WireGuardStatusItem _$WireGuardStatusItemFromJson(Map<String, dynamic> json) =>
     WireGuardStatusItem(
-      interfaceName: json['if'] as String,
-      type: json['type'] as String,
-      publicKey: json['public-key'] as String,
-      listenPort: json['listen-port'] as String,
-      fwmark: json['fwmark'] as String,
-      endpoint: json['endpoint'] as String,
-      status: json['status'] as String,
+      interfaceName: json['if'] as String?,
+      type: json['type'] as String?,
+      publicKey: json['public-key'] as String?,
+      listenPort: json['listen-port'] as String?,
+      fwmark: json['fwmark'] as String?,
+      endpoint: json['endpoint'] as String?,
+      status: json['status'] as String?,
       name: json['name'] as String?,
       latestHandshakeAge: (json['latest-handshake-age'] as num?)?.toInt(),
       latestHandshakeEpoch: json['latest-handshake-epoch'] as String?,
-      peerStatus: json['peer-status'] as String,
-      ifname: json['ifname'] as String,
+      peerStatus: json['peer-status'] as String?,
+      ifname: json['ifname'] as String?,
     );
 
 Map<String, dynamic> _$WireGuardStatusItemToJson(

--- a/lib/widgets/wireguard/status_card.dart
+++ b/lib/widgets/wireguard/status_card.dart
@@ -57,7 +57,7 @@ class StatusCard extends StatelessWidget {
                 // Interface name (ifname)
                 Expanded(
                   child: Text(
-                    item.ifname,
+                    item.ifname ?? '',
                     style: const TextStyle(
                       fontWeight: FontWeight.bold,
                       fontSize: 16,
@@ -72,7 +72,7 @@ class StatusCard extends StatelessWidget {
                     borderRadius: BorderRadius.circular(4),
                   ),
                   child: Text(
-                    item.type,
+                    item.type ?? '',
                     style: TextStyle(
                       color: item.isInterface ? AppColors.info : AppColors.warning,
                       fontWeight: FontWeight.w500,
@@ -84,22 +84,24 @@ class StatusCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             
-            // Status (up/down)
-            _buildInfoRow(
-              context,
-              l10n.status,
-              item.status.toUpperCase(),
-              icon: Icons.power_settings_new,
-              valueColor: item.isUp ? AppColors.success : AppColors.error,
-            ),
+            // Status (up/down) — only present on interface rows
+            if (item.status != null)
+              _buildInfoRow(
+                context,
+                l10n.status,
+                item.status!.toUpperCase(),
+                icon: Icons.power_settings_new,
+                valueColor: item.isUp ? AppColors.success : AppColors.error,
+              ),
             
             // Device (interface name like wg0, wg1)
-            _buildInfoRow(
-              context,
-              l10n.device,
-              item.interfaceName,
-              icon: Icons.router,
-            ),
+            if (item.interfaceName != null)
+              _buildInfoRow(
+                context,
+                l10n.device,
+                item.interfaceName!,
+                icon: Icons.router,
+              ),
             
             // Name/Description (only if not null and not empty)
             if (item.name != null && item.name!.isNotEmpty)
@@ -110,38 +112,44 @@ class StatusCard extends StatelessWidget {
                 icon: Icons.label,
               ),
             
-            // Listen Port
-            _buildInfoRow(
-              context,
-              l10n.listenPort,
-              item.listenPort,
-              icon: Icons.settings_ethernet,
-            ),
-            
-            // Endpoint (only if different from listen port and not empty)
-            if (item.endpoint.isNotEmpty && item.endpoint != item.listenPort)
+            // Listen Port — only present on interface rows
+            if (item.listenPort != null)
+              _buildInfoRow(
+                context,
+                l10n.listenPort,
+                item.listenPort!,
+                icon: Icons.settings_ethernet,
+              ),
+
+            // Endpoint (only if not null, not empty, and different from listen port)
+            if (item.endpoint != null &&
+                item.endpoint!.isNotEmpty &&
+                item.endpoint != item.listenPort)
               _buildInfoRow(
                 context,
                 l10n.endpoint,
-                item.endpoint,
+                item.endpoint!,
                 icon: Icons.location_on,
               ),
-            
-            // Firewall Mark (only if not "off" or "0")
-            if (item.fwmark.isNotEmpty && item.fwmark != 'off' && item.fwmark != '0')
+
+            // Firewall Mark — only present on interface rows; hide if "off" or "0"
+            if (item.fwmark != null &&
+                item.fwmark!.isNotEmpty &&
+                item.fwmark != 'off' &&
+                item.fwmark != '0')
               _buildInfoRow(
                 context,
                 l10n.fwMark,
-                item.fwmark,
+                item.fwmark!,
                 icon: Icons.security,
               ),
             
             // Peer Status (only if not null and not empty)
-            if (item.peerStatus.isNotEmpty)
+            if (item.peerStatus != null && item.peerStatus!.isNotEmpty)
               _buildInfoRow(
                 context,
                 l10n.peerStatus,
-                item.peerStatus,
+                item.peerStatus!,
                 icon: Icons.link,
                 valueColor: item.isOnline ? AppColors.success : AppColors.disabled,
               ),
@@ -155,12 +163,12 @@ class StatusCard extends StatelessWidget {
                 icon: Icons.access_time,
               ),
             
-            // Public Key (only if value is not "(none)" and not empty)
+            // Public Key (only if not null, not "(none)", and not empty)
             if (item.hasPublicKey)
               _buildInfoRow(
                 context,
                 l10n.publicKey,
-                item.publicKey,
+                item.publicKey!,
                 icon: Icons.vpn_key,
                 monospace: true,
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: opnsense_manager
 description: "OPNsense Manager - A professional Flutter mobile application for managing OPNsense firewall routers."
 publish_to: 'none'
 
-version: 1.7.2+14
+version: 1.8.0+15
 
 environment:
   sdk: '>=3.12.0 <4.0.0'


### PR DESCRIPTION
## Summary

Makes all conditionally-present fields in `WireGuardStatusItem` nullable to prevent runtime errors when the OPNsense API omits peer-only or interface-only fields.

## Changes

- Made `interfaceName`, `type`, `publicKey`, `listenPort`, `fwmark`, `endpoint`, `status`, `peerStatus`, and `ifname` nullable in `WireGuardStatusItem`
- Updated `wireguard_status.g.dart` to deserialize all affected fields as nullable types
- Updated computed getters (`isUp`, `isInterface`, `isPeer`, `isOnline`, `listenPortNumber`, `hasPublicKey`) to use null-safe access
- Updated `status_card.dart` to conditionally render interface-only fields (`status`, `interfaceName`, `listenPort`, `endpoint`, `fwmark`) only when non-null
- Bumped version to `1.8.0+15`
- Updated `CHANGELOG.md` with fix entry