### PR TITLE
Add long press copy and text selection to DHCP leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to OPNsense Manager will be documented in this file.
 ### Changed
 
 - Comprehensive refactor of the codebase covering color token migration, constants extraction, l10n cleanup, ViewModel pattern adoption, and shared utility/widget extraction.
+- Added the option to Long Press DHCP lease to copy the contents.
+- Adjusted the DHCP Card to be able to select text inside the widget 
 
 ### Fixed
 

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -1637,6 +1637,8 @@
       }
     }
   },
+  "longPressToCopy": "Long press to copy",
+  "@longPressToCopy": {},
   "logDetails": "تفاصيل السجل",
   "@logDetails": {},
   "logEntryCopied": "تم نسخ إدخال السجل",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1644,6 +1644,8 @@
       }
     }
   },
+  "longPressToCopy": "Long press to copy",
+  "@longPressToCopy": {},
   "logDetails": "Protokolldetails",
   "@logDetails": {},
   "logEntryCopied": "Protokolleintrag kopiert",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1608,6 +1608,8 @@
       }
     }
   },
+  "longPressToCopy": "Long press to copy",
+  "@longPressToCopy": {},
   "logDetails": "Log Details",
   "@logDetails": {},
   "logEntryCopied": "Log entry copied",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1644,6 +1644,8 @@
       }
     }
   },
+  "longPressToCopy": "Long press to copy",
+  "@longPressToCopy": {},
   "logDetails": "Detalles del registro",
   "@logDetails": {},
   "logEntryCopied": "Entrada de registro copiada",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1644,6 +1644,8 @@
       }
     }
   },
+  "longPressToCopy": "Long press to copy",
+  "@longPressToCopy": {},
   "logDetails": "Détails du journal",
   "@logDetails": {},
   "logEntryCopied": "Entrée de journal copiée",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3224,6 +3224,12 @@ abstract class AppLocalizations {
   /// **'Lock timeout set to {value} {value, plural, =1{minute} other{minutes}}'**
   String lockTimeoutSet(int value);
 
+  /// No description provided for @longPressToCopy.
+  ///
+  /// In en, this message translates to:
+  /// **'Long press to copy'**
+  String get longPressToCopy;
+
   /// No description provided for @logDetails.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1795,6 +1795,9 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get longPressToCopy => 'Long press to copy';
+
+  @override
   String get logDetails => 'تفاصيل السجل';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1829,6 +1829,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get longPressToCopy => 'Long press to copy';
+
+  @override
   String get logDetails => 'Protokolldetails';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1803,6 +1803,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get longPressToCopy => 'Long press to copy';
+
+  @override
   String get logDetails => 'Log Details';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1823,6 +1823,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get longPressToCopy => 'Long press to copy';
+
+  @override
   String get logDetails => 'Detalles del registro';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1826,6 +1826,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get longPressToCopy => 'Long press to copy';
+
+  @override
   String get logDetails => 'Détails du journal';
 
   @override

--- a/lib/screens/dhcp_leases_screen.dart
+++ b/lib/screens/dhcp_leases_screen.dart
@@ -26,6 +26,7 @@ import '../services/demo_api_service.dart';
 import '../services/profile_service.dart';
 import '../utils/app_colors.dart';
 import '../utils/constants.dart';
+import '../utils/snackbar_helper.dart';
 import '../utils/single_init_mixin.dart';
 import '../viewmodels/dhcp_leases_view_model.dart';
 import '../widgets/app_drawer.dart';
@@ -403,10 +404,16 @@ class _DhcpLeasesScreenState extends State<DhcpLeasesScreen>
     final l10n = AppLocalizations.of(context)!;
     final isExpired = lease.isExpired;
     
-    return Card(
+    return Tooltip(
+      message: l10n.longPressToCopy,
+      child: Card(
       margin: const EdgeInsets.only(bottom: 8),
       child: InkWell(
         onTap: () => _showLeaseDetails(lease),
+        onLongPress: () {
+          final text = '${lease.hostname}, ${lease.address}, ${lease.macAddress}';
+          SnackBarHelper.copyToClipboard(context, text);
+        },
         borderRadius: BorderRadius.circular(12),
         child: Padding(
           padding: const EdgeInsets.all(12),
@@ -571,6 +578,7 @@ class _DhcpLeasesScreenState extends State<DhcpLeasesScreen>
           ),
         ),
       ),
+    ),
     );
   }
 
@@ -627,38 +635,40 @@ class _DhcpLeasesScreenState extends State<DhcpLeasesScreen>
             ),
           ],
         ),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildDetailRow(l10n.ipAddress, lease.address),
-              _buildDetailRow(l10n.macAddress, lease.macAddress),
-              if (lease.manufacturer != null)
-                _buildDetailRow(l10n.manufacturer, lease.manufacturer!),
-              if (lease.interface != null)
-                _buildDetailRow(l10n.interface, lease.interface!),
-              const Divider(height: 24),
-              _buildDetailRow(
-                l10n.status,
-                lease.isExpired ? l10n.expired : l10n.active,
-              ),
-              if (lease.startDateTime != null)
+        content: SelectionArea(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildDetailRow(l10n.ipAddress, lease.address),
+                _buildDetailRow(l10n.macAddress, lease.macAddress),
+                if (lease.manufacturer != null)
+                  _buildDetailRow(l10n.manufacturer, lease.manufacturer!),
+                if (lease.interface != null)
+                  _buildDetailRow(l10n.interface, lease.interface!),
+                const Divider(height: 24),
                 _buildDetailRow(
-                  l10n.startTime,
-                  dateFormat.format(lease.startDateTime!),
+                  l10n.status,
+                  lease.isExpired ? l10n.expired : l10n.active,
                 ),
-              if (lease.expiryDateTime != null)
-                _buildDetailRow(
-                  l10n.expiryTime,
-                  dateFormat.format(lease.expiryDateTime!),
-                ),
-              if (lease.endDateTime != null)
-                _buildDetailRow(
-                  l10n.endTime,
-                  dateFormat.format(lease.endDateTime!),
-                ),
-            ],
+                if (lease.startDateTime != null)
+                  _buildDetailRow(
+                    l10n.startTime,
+                    dateFormat.format(lease.startDateTime!),
+                  ),
+                if (lease.expiryDateTime != null)
+                  _buildDetailRow(
+                    l10n.expiryTime,
+                    dateFormat.format(lease.expiryDateTime!),
+                  ),
+                if (lease.endDateTime != null)
+                  _buildDetailRow(
+                    l10n.endTime,
+                    dateFormat.format(lease.endDateTime!),
+                  ),
+              ],
+            ),
           ),
         ),
         actions: [


### PR DESCRIPTION
## Summary

Adds long press copy and text selection to the DHCP leases screen, allowing users to quickly copy lease details to the clipboard and select text within the lease detail dialog.

## Changes

- Added long press handler to DHCP lease cards to copy hostname, IP address, and MAC address to clipboard
- Wrapped lease card with `Tooltip` showing `longPressToCopy` hint on long press
- Wrapped lease detail dialog content with `SelectionArea` to enable text selection
- Added `longPressToCopy` localization key to all supported locales (`app_en.arb`, `app_ar.arb`, `app_de.arb`, `app_es.arb`, `app_fr.arb`)
- Updated generated localization files (`app_localizations.dart` and per-locale subclasses)
- Updated `CHANGELOG.md` with feature entry