### PR TITLE
Add firmware update screen with live log and reboot polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 All notable changes to OPNsense Manager will be documented in this file.
 
-## [1.8.0] - 
+## [1.8.0] -
 
 ### Added
 
+- Added Firmware Update screen with the ability to check for available updates, view the current installed and latest versions, and install updates directly from the app.
+- Firmware update screen shows a live log terminal while an update is running, with a reboot prompt when required.
+- Detects when an OPNsense firmware upgrade is already in progress and attaches to the live log stream, showing an "Upgrade in progress…" banner until it completes.
 
 ### Changed
 

--- a/lib/constants/api_endpoints.dart
+++ b/lib/constants/api_endpoints.dart
@@ -27,6 +27,10 @@ class ApiEndpoints {
   static const String systemStatus = '/core/system/status';
   static const String firmwareInfo = '/core/firmware/info';
   static const String firmwareStatus = '/core/firmware/status';
+  static const String firmwareCheck = '/core/firmware/check';
+  static const String firmwareUpdate = '/core/firmware/update';
+  static const String firmwareUpgradeStatus = '/core/firmware/upgradestatus';
+  static String firmwareChangelog(String version) => '/core/firmware/changelog/$version';
   static const String systemInfo = '/core/system/info';
   static const String systemDisk = '/core/system/systemDisk';
   static const String systemReboot = '/core/system/reboot';

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -269,6 +269,31 @@
   "@bytesSent": {},
   "cancel": "إلغاء",
   "@cancel": {},
+  "checkForUpdates": "Check for Updates",
+  "@checkForUpdates": {},
+  "checkingForUpdates": "Checking for updates\u2026",
+  "@checkingForUpdates": {},
+
+  "installUpdate": "Install Update",
+  "@installUpdate": {},
+  "installingUpdate": "Installing update\u2026",
+  "@installingUpdate": {},
+  "updateComplete": "Update installed successfully",
+  "@updateComplete": {},
+  "rebootRequired": "A reboot is required to complete the update.",
+  "@rebootRequired": {},
+  "rebootNow": "Reboot Now",
+  "@rebootNow": {},
+  "installUpdateConfirmTitle": "Install Update",
+  "@installUpdateConfirmTitle": {},
+  "installUpdateConfirmMessage": "This will upgrade {count} package(s) and requires a reboot to complete. Continue?",
+  "@installUpdateConfirmMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "cannotBeUndone": "لا يمكن التراجع عن هذا الإجراء.",
   "@cannotBeUndone": {},
   "cannotDeleteLastConnection": "لا يمكن حذف نقطة الاتصال الأخيرة",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -269,6 +269,31 @@
   "@bytesSent": {},
   "cancel": "Abbrechen",
   "@cancel": {},
+  "checkForUpdates": "Updates prüfen",
+  "@checkForUpdates": {},
+  "checkingForUpdates": "Updates werden geprüft\u2026",
+  "@checkingForUpdates": {},
+
+  "installUpdate": "Update installieren",
+  "@installUpdate": {},
+  "installingUpdate": "Update wird installiert\u2026",
+  "@installingUpdate": {},
+  "updateComplete": "Update erfolgreich installiert",
+  "@updateComplete": {},
+  "rebootRequired": "Ein Neustart ist erforderlich, um das Update abzuschließen.",
+  "@rebootRequired": {},
+  "rebootNow": "Jetzt neu starten",
+  "@rebootNow": {},
+  "installUpdateConfirmTitle": "Update installieren",
+  "@installUpdateConfirmTitle": {},
+  "installUpdateConfirmMessage": "This will upgrade {count} package(s) and requires a reboot to complete. Continue?",
+  "@installUpdateConfirmMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "cannotBeUndone": "Diese Aktion kann nicht rückgängig gemacht werden.",
   "@cannotBeUndone": {},
   "cannotDeleteLastConnection": "Der letzte Verbindungsendpunkt kann nicht gelöscht werden",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -262,6 +262,30 @@
   "@bytesSent": {},
   "cancel": "Cancel",
   "@cancel": {},
+  "checkForUpdates": "Check for Updates",
+  "@checkForUpdates": {},
+  "checkingForUpdates": "Checking for updates\u2026",
+  "@checkingForUpdates": {},
+  "installUpdate": "Install Update",
+  "@installUpdate": {},
+  "installingUpdate": "Installing update\u2026",
+  "@installingUpdate": {},
+  "updateComplete": "Update installed successfully",
+  "@updateComplete": {},
+  "rebootRequired": "A reboot is required to complete the update.",
+  "@rebootRequired": {},
+  "rebootNow": "Reboot Now",
+  "@rebootNow": {},
+  "installUpdateConfirmTitle": "Install Update",
+  "@installUpdateConfirmTitle": {},
+  "installUpdateConfirmMessage": "This will upgrade {count} package(s) and requires a reboot to complete. Continue?",
+  "@installUpdateConfirmMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "cannotBeUndone": "This action cannot be undone.",
   "@cannotBeUndone": {},
   "cannotDeleteLastConnection": "Cannot delete the last connection endpoint",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -269,6 +269,31 @@
   "@bytesSent": {},
   "cancel": "Cancelar",
   "@cancel": {},
+  "checkForUpdates": "Buscar actualizaciones",
+  "@checkForUpdates": {},
+  "checkingForUpdates": "Buscando actualizaciones\u2026",
+  "@checkingForUpdates": {},
+
+  "installUpdate": "Instalar actualización",
+  "@installUpdate": {},
+  "installingUpdate": "Instalando actualización\u2026",
+  "@installingUpdate": {},
+  "updateComplete": "Actualización instalada correctamente",
+  "@updateComplete": {},
+  "rebootRequired": "Se requiere un reinicio para completar la actualización.",
+  "@rebootRequired": {},
+  "rebootNow": "Reiniciar ahora",
+  "@rebootNow": {},
+  "installUpdateConfirmTitle": "Instalar actualización",
+  "@installUpdateConfirmTitle": {},
+  "installUpdateConfirmMessage": "This will upgrade {count} package(s) and requires a reboot to complete. Continue?",
+  "@installUpdateConfirmMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "cannotBeUndone": "Esta acción no se puede deshacer.",
   "@cannotBeUndone": {},
   "cannotDeleteLastConnection": "No se puede eliminar el último punto de conexión",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -269,6 +269,31 @@
   "@bytesSent": {},
   "cancel": "Annuler",
   "@cancel": {},
+  "checkForUpdates": "Vérifier les mises à jour",
+  "@checkForUpdates": {},
+  "checkingForUpdates": "Vérification des mises à jour\u2026",
+  "@checkingForUpdates": {},
+
+  "installUpdate": "Installer la mise à jour",
+  "@installUpdate": {},
+  "installingUpdate": "Installation en cours\u2026",
+  "@installingUpdate": {},
+  "updateComplete": "Mise à jour installée avec succès",
+  "@updateComplete": {},
+  "rebootRequired": "Un redémarrage est nécessaire pour terminer la mise à jour.",
+  "@rebootRequired": {},
+  "rebootNow": "Redémarrer maintenant",
+  "@rebootNow": {},
+  "installUpdateConfirmTitle": "Installer la mise à jour",
+  "@installUpdateConfirmTitle": {},
+  "installUpdateConfirmMessage": "This will upgrade {count} package(s) and requires a reboot to complete. Continue?",
+  "@installUpdateConfirmMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "cannotBeUndone": "Cette action ne peut pas être annulée.",
   "@cannotBeUndone": {},
   "cannotDeleteLastConnection": "Impossible de supprimer le dernier point de terminaison de connexion",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -740,6 +740,60 @@ abstract class AppLocalizations {
   /// **'Cancel'**
   String get cancel;
 
+  /// No description provided for @checkForUpdates.
+  ///
+  /// In en, this message translates to:
+  /// **'Check for Updates'**
+  String get checkForUpdates;
+
+  /// No description provided for @checkingForUpdates.
+  ///
+  /// In en, this message translates to:
+  /// **'Checking for updates…'**
+  String get checkingForUpdates;
+
+  /// No description provided for @installUpdate.
+  ///
+  /// In en, this message translates to:
+  /// **'Install Update'**
+  String get installUpdate;
+
+  /// No description provided for @installingUpdate.
+  ///
+  /// In en, this message translates to:
+  /// **'Installing update…'**
+  String get installingUpdate;
+
+  /// No description provided for @updateComplete.
+  ///
+  /// In en, this message translates to:
+  /// **'Update installed successfully'**
+  String get updateComplete;
+
+  /// No description provided for @rebootRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'A reboot is required to complete the update.'**
+  String get rebootRequired;
+
+  /// No description provided for @rebootNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Reboot Now'**
+  String get rebootNow;
+
+  /// No description provided for @installUpdateConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Install Update'**
+  String get installUpdateConfirmTitle;
+
+  /// No description provided for @installUpdateConfirmMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This will upgrade {count} package(s) and requires a reboot to complete. Continue?'**
+  String installUpdateConfirmMessage(int count);
+
   /// No description provided for @cannotBeUndone.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -349,6 +349,35 @@ class AppLocalizationsAr extends AppLocalizations {
   String get cancel => 'إلغاء';
 
   @override
+  String get checkForUpdates => 'Check for Updates';
+
+  @override
+  String get checkingForUpdates => 'Checking for updates…';
+
+  @override
+  String get installUpdate => 'Install Update';
+
+  @override
+  String get installingUpdate => 'Installing update…';
+
+  @override
+  String get updateComplete => 'Update installed successfully';
+
+  @override
+  String get rebootRequired => 'A reboot is required to complete the update.';
+
+  @override
+  String get rebootNow => 'Reboot Now';
+
+  @override
+  String get installUpdateConfirmTitle => 'Install Update';
+
+  @override
+  String installUpdateConfirmMessage(int count) {
+    return 'This will upgrade $count package(s) and requires a reboot to complete. Continue?';
+  }
+
+  @override
   String get cannotBeUndone => 'لا يمكن التراجع عن هذا الإجراء.';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -362,6 +362,36 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cancel => 'Abbrechen';
 
   @override
+  String get checkForUpdates => 'Updates prüfen';
+
+  @override
+  String get checkingForUpdates => 'Updates werden geprüft…';
+
+  @override
+  String get installUpdate => 'Update installieren';
+
+  @override
+  String get installingUpdate => 'Update wird installiert…';
+
+  @override
+  String get updateComplete => 'Update erfolgreich installiert';
+
+  @override
+  String get rebootRequired =>
+      'Ein Neustart ist erforderlich, um das Update abzuschließen.';
+
+  @override
+  String get rebootNow => 'Jetzt neu starten';
+
+  @override
+  String get installUpdateConfirmTitle => 'Update installieren';
+
+  @override
+  String installUpdateConfirmMessage(int count) {
+    return 'This will upgrade $count package(s) and requires a reboot to complete. Continue?';
+  }
+
+  @override
   String get cannotBeUndone =>
       'Diese Aktion kann nicht rückgängig gemacht werden.';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -353,6 +353,35 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cancel => 'Cancel';
 
   @override
+  String get checkForUpdates => 'Check for Updates';
+
+  @override
+  String get checkingForUpdates => 'Checking for updates…';
+
+  @override
+  String get installUpdate => 'Install Update';
+
+  @override
+  String get installingUpdate => 'Installing update…';
+
+  @override
+  String get updateComplete => 'Update installed successfully';
+
+  @override
+  String get rebootRequired => 'A reboot is required to complete the update.';
+
+  @override
+  String get rebootNow => 'Reboot Now';
+
+  @override
+  String get installUpdateConfirmTitle => 'Install Update';
+
+  @override
+  String installUpdateConfirmMessage(int count) {
+    return 'This will upgrade $count package(s) and requires a reboot to complete. Continue?';
+  }
+
+  @override
   String get cannotBeUndone => 'This action cannot be undone.';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -361,6 +361,36 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cancel => 'Cancelar';
 
   @override
+  String get checkForUpdates => 'Buscar actualizaciones';
+
+  @override
+  String get checkingForUpdates => 'Buscando actualizaciones…';
+
+  @override
+  String get installUpdate => 'Instalar actualización';
+
+  @override
+  String get installingUpdate => 'Instalando actualización…';
+
+  @override
+  String get updateComplete => 'Actualización instalada correctamente';
+
+  @override
+  String get rebootRequired =>
+      'Se requiere un reinicio para completar la actualización.';
+
+  @override
+  String get rebootNow => 'Reiniciar ahora';
+
+  @override
+  String get installUpdateConfirmTitle => 'Instalar actualización';
+
+  @override
+  String installUpdateConfirmMessage(int count) {
+    return 'This will upgrade $count package(s) and requires a reboot to complete. Continue?';
+  }
+
+  @override
   String get cannotBeUndone => 'Esta acción no se puede deshacer.';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -360,6 +360,36 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cancel => 'Annuler';
 
   @override
+  String get checkForUpdates => 'Vérifier les mises à jour';
+
+  @override
+  String get checkingForUpdates => 'Vérification des mises à jour…';
+
+  @override
+  String get installUpdate => 'Installer la mise à jour';
+
+  @override
+  String get installingUpdate => 'Installation en cours…';
+
+  @override
+  String get updateComplete => 'Mise à jour installée avec succès';
+
+  @override
+  String get rebootRequired =>
+      'Un redémarrage est nécessaire pour terminer la mise à jour.';
+
+  @override
+  String get rebootNow => 'Redémarrer maintenant';
+
+  @override
+  String get installUpdateConfirmTitle => 'Installer la mise à jour';
+
+  @override
+  String installUpdateConfirmMessage(int count) {
+    return 'This will upgrade $count package(s) and requires a reboot to complete. Continue?';
+  }
+
+  @override
   String get cannotBeUndone => 'Cette action ne peut pas être annulée.';
 
   @override

--- a/lib/models/firmware_update_status.dart
+++ b/lib/models/firmware_update_status.dart
@@ -1,0 +1,107 @@
+/*
+ * OPNsense Manager - Flutter application for managing OPNsense firewalls
+ * Copyright (C) 2026 OPNsense Manager
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/// Firmware update status model.
+///
+/// Parsed from `GET /api/core/firmware/status` with optional changelog
+/// data from `POST /api/core/firmware/changelog/{version}`.
+class FirmwareUpdateStatus {
+  /// The currently installed version (product.product_version).
+  final String currentVersion;
+
+  /// The latest available version (product.product_latest).
+  final String latestVersion;
+
+  /// Whether any updates are available (upgrade_packages or new_packages non-empty).
+  final bool updatesAvailable;
+
+  /// Whether a reboot is required after upgrade (needs_reboot == "1").
+  final bool needsReboot;
+
+  /// Human-readable download size string (download_size).
+  final String downloadSize;
+
+  /// Timestamp of the last firmware check (last_check).
+  final String lastCheck;
+
+  /// Number of packages to be upgraded (upgrade_packages.length).
+  final int upgradeCount;
+
+  /// Number of new packages to be installed (new_packages.length).
+  final int newPackageCount;
+
+  /// Packages to be upgraded. Each map has keys: name, current_version, new_version.
+  final List<Map<String, String>> upgradePackages;
+
+  /// New packages to be installed. Each map has keys: name, version.
+  final List<Map<String, String>> newPackages;
+
+  /// Plain text changelog (HTML tags stripped from changelog endpoint response).
+  final String? changelogText;
+
+  /// Changelog date string from the changelog endpoint.
+  final String? changelogDate;
+
+  const FirmwareUpdateStatus({
+    required this.currentVersion,
+    required this.latestVersion,
+    required this.updatesAvailable,
+    required this.needsReboot,
+    required this.downloadSize,
+    required this.lastCheck,
+    required this.upgradeCount,
+    required this.newPackageCount,
+    required this.upgradePackages,
+    required this.newPackages,
+    this.changelogText,
+    this.changelogDate,
+  });
+
+  /// Returns an "up to date" status with no pending packages.
+  factory FirmwareUpdateStatus.noUpdates({
+    String currentVersion = '',
+    String latestVersion = '',
+  }) {
+    return FirmwareUpdateStatus(
+      currentVersion: currentVersion,
+      latestVersion: latestVersion,
+      updatesAvailable: false,
+      needsReboot: false,
+      downloadSize: '',
+      lastCheck: '',
+      upgradeCount: 0,
+      newPackageCount: 0,
+      upgradePackages: const [],
+      newPackages: const [],
+    );
+  }
+
+  /// Total number of packages affected (upgraded + new).
+  int get totalPackageCount => upgradeCount + newPackageCount;
+
+  @override
+  String toString() {
+    return 'FirmwareUpdateStatus('
+        'currentVersion: $currentVersion, '
+        'latestVersion: $latestVersion, '
+        'updatesAvailable: $updatesAvailable, '
+        'upgradeCount: $upgradeCount, '
+        'newPackageCount: $newPackageCount'
+        ')';
+  }
+}

--- a/lib/screens/firmware_update_screen.dart
+++ b/lib/screens/firmware_update_screen.dart
@@ -1,0 +1,470 @@
+/*
+ * OPNsense Manager - Flutter application for managing OPNsense firewalls
+ * Copyright (C) 2026 OPNsense Manager
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import '../models/firmware_update_status.dart';
+import '../screens/dashboard_screen.dart';
+import '../services/demo_api_service.dart';
+import '../utils/single_init_mixin.dart';
+import '../utils/snackbar_helper.dart';
+import '../viewmodels/firmware_update_view_model.dart';
+import '../widgets/common/confirmation_dialog.dart';
+import '../widgets/common/error_display.dart';
+import '../l10n/app_localizations.dart';
+
+/// Dedicated screen for checking firmware updates and installing them.
+///
+/// Navigated to from [SystemInfoScreen] via [Navigator.push].
+/// Owns its own [FirmwareUpdateViewModel] and starts the check automatically.
+class FirmwareUpdateScreen extends StatefulWidget {
+  const FirmwareUpdateScreen({super.key});
+
+  @override
+  State<FirmwareUpdateScreen> createState() => _FirmwareUpdateScreenState();
+}
+
+class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
+    with SingleInitMixin {
+  late FirmwareUpdateViewModel _viewModel;
+
+  // Auto-scroll controller for the log terminal.
+  final ScrollController _logScrollController = ScrollController();
+
+  @override
+  void onFirstDependency() {
+    _viewModel = FirmwareUpdateViewModel(context.read<DemoApiService>());
+    _viewModel.addListener(_scrollToBottom);
+    _viewModel.checkForUpdates();
+  }
+
+  @override
+  void dispose() {
+    _viewModel.removeListener(_scrollToBottom);
+    _viewModel.dispose();
+    _logScrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_logScrollController.hasClients) {
+        _logScrollController.animateTo(
+          _logScrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  // ── Build ──────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return ListenableBuilder(
+      listenable: _viewModel,
+      builder: (context, _) {
+        final busy = _viewModel.isChecking || _viewModel.isUpdating;
+        final hasLog = _viewModel.checkLog?.isNotEmpty == true;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(l10n.checkForUpdates),
+            actions: [
+              // Copy log to clipboard — visible whenever there is log content.
+              if (hasLog)
+                IconButton(
+                  icon: const Icon(Icons.copy_outlined),
+                  tooltip: 'Copy output',
+                  onPressed: () => _copyLog(context),
+                ),
+              // Re-check button — only shown when idle.
+              if (!busy)
+                IconButton(
+                  icon: const Icon(Icons.refresh),
+                  tooltip: l10n.refresh,
+                  onPressed: _viewModel.checkForUpdates,
+                ),
+            ],
+          ),
+          body: _buildBody(l10n),
+        );
+      },
+    );
+  }
+
+  // ── Body dispatcher ────────────────────────────────────────────────────────
+
+  Widget _buildBody(AppLocalizations l10n) {
+    // Update complete — reboot prompt
+    if (_viewModel.isUpdateComplete) {
+      return _buildUpdateComplete(l10n);
+    }
+
+    // Checking or installing — show live log terminal
+    if (_viewModel.isChecking || _viewModel.isUpdating) {
+      return _buildLogView(
+        title: _viewModel.isUpdating
+            ? l10n.installingUpdate
+            : l10n.checkingForUpdates,
+        isRunning: true,
+      );
+    }
+
+    // Error with no results
+    if (_viewModel.errorMessage != null && _viewModel.firmwareStatus == null) {
+      // If we have log output from the failed run, show it below the error.
+      return Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ErrorDisplay(
+              message: _viewModel.errorMessage!,
+              onRetry: _viewModel.checkForUpdates,
+            ),
+          ),
+          if (_viewModel.checkLog?.isNotEmpty == true)
+            Expanded(child: _buildLogView(title: 'Output', isRunning: false)),
+        ],
+      );
+    }
+
+    final status = _viewModel.firmwareStatus;
+    if (status == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    // Results — show summary + optional full log below
+    return _buildResultsView(l10n, status);
+  }
+
+  // ── Log terminal view ──────────────────────────────────────────────────────
+
+  Widget _buildLogView({required String title, required bool isRunning}) {
+    final theme = Theme.of(context);
+    final log = _viewModel.checkLog ?? '';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Header bar
+        Container(
+          color: theme.colorScheme.surfaceContainerHighest,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              if (isRunning) ...[
+                SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(width: 8),
+              ],
+              Text(title,
+                  style: theme.textTheme.labelMedium
+                      ?.copyWith(fontWeight: FontWeight.bold)),
+            ],
+          ),
+        ),
+        // Scrollable monospace terminal
+        Expanded(
+          child: Container(
+            color: const Color(0xFF1E1E1E),
+            padding: const EdgeInsets.all(12),
+            child: SingleChildScrollView(
+              controller: _logScrollController,
+              child: SelectableText(
+                log,
+                style: const TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                  color: Color(0xFFD4D4D4),
+                  height: 1.5,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── Results view ───────────────────────────────────────────────────────────
+
+  Widget _buildResultsView(AppLocalizations l10n, FirmwareUpdateStatus status) {
+    final theme = Theme.of(context);
+    final upToDate = !status.updatesAvailable;
+
+    return Column(
+      children: [
+        // Summary card (fixed height content)
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Version row
+                  Row(
+                    children: [
+                      Icon(
+                        upToDate
+                            ? Icons.check_circle_outline
+                            : Icons.system_update_outlined,
+                        color: upToDate
+                            ? theme.colorScheme.primary
+                            : theme.colorScheme.error,
+                      ),
+                      const SizedBox(width: 8),
+                      if (upToDate)
+                        Text('Up to date',
+                            style: theme.textTheme.titleMedium)
+                      else ...[
+                        Text(status.currentVersion,
+                            style: theme.textTheme.titleMedium),
+                        const SizedBox(width: 8),
+                        const Icon(Icons.arrow_forward, size: 18),
+                        const SizedBox(width: 8),
+                        Text(
+                          status.latestVersion,
+                          style: theme.textTheme.titleMedium
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
+                      ],
+                    ],
+                  ),
+                  if (status.updatesAvailable) ...[
+                    const SizedBox(height: 6),
+                    Text('${status.totalPackageCount} package(s) to update',
+                        style: theme.textTheme.bodySmall),
+                    if (status.downloadSize.isNotEmpty)
+                      Text('Download: ${status.downloadSize}',
+                          style: theme.textTheme.bodySmall),
+                    if (status.needsReboot) ...[
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          Icon(Icons.warning_amber_outlined,
+                              size: 16, color: theme.colorScheme.error),
+                          const SizedBox(width: 4),
+                          Text(
+                            'Reboot required after update',
+                            style: theme.textTheme.bodySmall
+                                ?.copyWith(color: theme.colorScheme.error),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ],
+                  if (status.lastCheck.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text('Last checked: ${status.lastCheck}',
+                        style: theme.textTheme.bodySmall),
+                  ],
+                  // Changelog
+                  if (status.changelogText != null) ...[
+                    const SizedBox(height: 8),
+                    ExpansionTile(
+                      tilePadding: EdgeInsets.zero,
+                      title: const Text("What's New"),
+                      subtitle: status.changelogDate != null
+                          ? Text(status.changelogDate!)
+                          : null,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child:
+                              Text(status.changelogText!, softWrap: true),
+                        ),
+                      ],
+                    ),
+                  ],
+                  // Package lists
+                  if (status.upgradeCount > 0) ...[
+                    const SizedBox(height: 4),
+                    ExpansionTile(
+                      tilePadding: EdgeInsets.zero,
+                      title: Text(
+                          'Packages to Upgrade (${status.upgradeCount})'),
+                      children: status.upgradePackages
+                          .map((pkg) => ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: Text(pkg['name']!),
+                                subtitle: Text(
+                                    '${pkg['current_version']} → ${pkg['new_version']}'),
+                                dense: true,
+                              ))
+                          .toList(),
+                    ),
+                  ],
+                  if (status.newPackageCount > 0) ...[
+                    const SizedBox(height: 4),
+                    ExpansionTile(
+                      tilePadding: EdgeInsets.zero,
+                      title:
+                          Text('New Packages (${status.newPackageCount})'),
+                      children: status.newPackages
+                          .map((pkg) => ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: Text(pkg['name']!),
+                                subtitle: Text('NEW · ${pkg['version']}'),
+                                dense: true,
+                              ))
+                          .toList(),
+                    ),
+                  ],
+                  // Install Update button
+                  if (status.updatesAvailable) ...[
+                    const SizedBox(height: 16),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton.icon(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: theme.colorScheme.error,
+                          foregroundColor: theme.colorScheme.onError,
+                        ),
+                        icon: const Icon(Icons.system_update_alt),
+                        label: Text(
+                            '${l10n.installUpdate} (${status.totalPackageCount} packages)'),
+                        onPressed: () => _confirmAndUpdate(l10n, status),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+        // Full check log below the summary card
+        if (_viewModel.checkLog?.isNotEmpty == true)
+          Expanded(
+            child: _buildLogView(title: 'Check output', isRunning: false),
+          ),
+      ],
+    );
+  }
+
+  // ── Update complete ────────────────────────────────────────────────────────
+
+  Widget _buildUpdateComplete(AppLocalizations l10n) {
+    final theme = Theme.of(context);
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                children: [
+                  Icon(Icons.check_circle_outline,
+                      size: 48, color: theme.colorScheme.primary),
+                  const SizedBox(height: 12),
+                  Text(
+                    l10n.updateComplete,
+                    style: theme.textTheme.titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
+                  if (_viewModel.updateRequiresReboot) ...[
+                    const SizedBox(height: 8),
+                    Text(l10n.rebootRequired,
+                        style: theme.textTheme.bodyMedium,
+                        textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton.icon(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: theme.colorScheme.error,
+                          foregroundColor: theme.colorScheme.onError,
+                        ),
+                        icon: const Icon(Icons.restart_alt),
+                        label: Text(l10n.rebootNow),
+                        onPressed: _rebootFirewall,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+        // Install log remains visible after completion
+        if (_viewModel.checkLog?.isNotEmpty == true)
+          Expanded(
+            child: _buildLogView(title: 'Install output', isRunning: false),
+          ),
+      ],
+    );
+  }
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  Future<void> _copyLog(BuildContext context) async {
+    final log = _viewModel.checkLog ?? '';
+    await Clipboard.setData(ClipboardData(text: log));
+    if (context.mounted) {
+      SnackBarHelper.showInfo(context, 'Output copied to clipboard');
+    }
+  }
+
+  Future<void> _confirmAndUpdate(
+      AppLocalizations l10n, FirmwareUpdateStatus status) async {
+    final confirmed = await ConfirmationDialog.show(
+      context: context,
+      title: l10n.installUpdateConfirmTitle,
+      message: l10n.installUpdateConfirmMessage(status.totalPackageCount),
+      confirmText: l10n.installUpdate,
+      cancelText: l10n.cancel,
+      isDestructive: true,
+    );
+    if (confirmed == true && mounted) {
+      unawaited(_viewModel.performUpdate());
+    }
+  }
+
+  Future<void> _rebootFirewall() async {
+    final apiService = context.read<DemoApiService>();
+    try {
+      await apiService.rebootSystem();
+    } catch (_) {
+      // Ignore — the firewall goes offline during reboot.
+    }
+    if (mounted) {
+      SnackBarHelper.showInfo(context, 'Rebooting firewall…');
+      unawaited(
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (_) => const DashboardScreen()),
+        ),
+      );
+    }
+  }
+}

--- a/lib/screens/firmware_update_screen.dart
+++ b/lib/screens/firmware_update_screen.dart
@@ -134,7 +134,16 @@ class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
 
     // Error with no results
     if (_viewModel.errorMessage != null && _viewModel.firmwareStatus == null) {
-      // If we have log output from the failed run, show it below the error.
+      final hasLog = _viewModel.checkLog?.isNotEmpty == true;
+      if (!hasLog) {
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: ErrorDisplay(
+            message: _viewModel.errorMessage!,
+            onRetry: _viewModel.checkForUpdates,
+          ),
+        );
+      }
       return Column(
         children: [
           Padding(
@@ -144,8 +153,7 @@ class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
               onRetry: _viewModel.checkForUpdates,
             ),
           ),
-          if (_viewModel.checkLog?.isNotEmpty == true)
-            Expanded(child: _buildLogView(title: 'Output', isRunning: false)),
+          Expanded(child: _buildLogView(title: 'Output', isRunning: false)),
         ],
       );
     }
@@ -220,153 +228,164 @@ class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
     final theme = Theme.of(context);
     final upToDate = !status.updatesAvailable;
 
-    return Column(
-      children: [
-        // Summary card (fixed height content)
-        Padding(
-          padding: const EdgeInsets.all(16),
-          child: Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Version row
-                  Row(
-                    children: [
-                      Icon(
-                        upToDate
-                            ? Icons.check_circle_outline
-                            : Icons.system_update_outlined,
-                        color: upToDate
-                            ? theme.colorScheme.primary
-                            : theme.colorScheme.error,
-                      ),
-                      const SizedBox(width: 8),
-                      if (upToDate)
-                        Text('Up to date',
-                            style: theme.textTheme.titleMedium)
-                      else ...[
-                        Text(status.currentVersion,
-                            style: theme.textTheme.titleMedium),
-                        const SizedBox(width: 8),
-                        const Icon(Icons.arrow_forward, size: 18),
-                        const SizedBox(width: 8),
-                        Text(
-                          status.latestVersion,
-                          style: theme.textTheme.titleMedium
-                              ?.copyWith(fontWeight: FontWeight.bold),
-                        ),
-                      ],
-                    ],
+    // When there is a log panel below, the summary must be scrollable and the
+    // log must fill the remaining space.  When there is no log, the whole body
+    // can simply scroll.
+    final hasLog = _viewModel.checkLog?.isNotEmpty == true;
+
+    Widget summaryCard = Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Version row
+            Row(
+              children: [
+                Icon(
+                  upToDate
+                      ? Icons.check_circle_outline
+                      : Icons.system_update_outlined,
+                  color: upToDate
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.error,
+                ),
+                const SizedBox(width: 8),
+                if (upToDate)
+                  Text('Up to date', style: theme.textTheme.titleMedium)
+                else ...[
+                  Text(status.currentVersion,
+                      style: theme.textTheme.titleMedium),
+                  const SizedBox(width: 8),
+                  const Icon(Icons.arrow_forward, size: 18),
+                  const SizedBox(width: 8),
+                  Text(
+                    status.latestVersion,
+                    style: theme.textTheme.titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
                   ),
-                  if (status.updatesAvailable) ...[
-                    const SizedBox(height: 6),
-                    Text('${status.totalPackageCount} package(s) to update',
-                        style: theme.textTheme.bodySmall),
-                    if (status.downloadSize.isNotEmpty)
-                      Text('Download: ${status.downloadSize}',
-                          style: theme.textTheme.bodySmall),
-                    if (status.needsReboot) ...[
-                      const SizedBox(height: 4),
-                      Row(
-                        children: [
-                          Icon(Icons.warning_amber_outlined,
-                              size: 16, color: theme.colorScheme.error),
-                          const SizedBox(width: 4),
-                          Text(
-                            'Reboot required after update',
-                            style: theme.textTheme.bodySmall
-                                ?.copyWith(color: theme.colorScheme.error),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ],
-                  if (status.lastCheck.isNotEmpty) ...[
-                    const SizedBox(height: 4),
-                    Text('Last checked: ${status.lastCheck}',
-                        style: theme.textTheme.bodySmall),
-                  ],
-                  // Changelog
-                  if (status.changelogText != null) ...[
-                    const SizedBox(height: 8),
-                    ExpansionTile(
-                      tilePadding: EdgeInsets.zero,
-                      title: const Text("What's New"),
-                      subtitle: status.changelogDate != null
-                          ? Text(status.changelogDate!)
-                          : null,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child:
-                              Text(status.changelogText!, softWrap: true),
-                        ),
-                      ],
+                ],
+              ],
+            ),
+            if (status.updatesAvailable) ...[
+              const SizedBox(height: 6),
+              Text('${status.totalPackageCount} package(s) to update',
+                  style: theme.textTheme.bodySmall),
+              if (status.downloadSize.isNotEmpty)
+                Text('Download: ${status.downloadSize}',
+                    style: theme.textTheme.bodySmall),
+              if (status.needsReboot) ...[
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Icon(Icons.warning_amber_outlined,
+                        size: 16, color: theme.colorScheme.error),
+                    const SizedBox(width: 4),
+                    Text(
+                      'Reboot required after update',
+                      style: theme.textTheme.bodySmall
+                          ?.copyWith(color: theme.colorScheme.error),
                     ),
                   ],
-                  // Package lists
-                  if (status.upgradeCount > 0) ...[
-                    const SizedBox(height: 4),
-                    ExpansionTile(
-                      tilePadding: EdgeInsets.zero,
-                      title: Text(
-                          'Packages to Upgrade (${status.upgradeCount})'),
-                      children: status.upgradePackages
-                          .map((pkg) => ListTile(
-                                contentPadding: EdgeInsets.zero,
-                                title: Text(pkg['name']!),
-                                subtitle: Text(
-                                    '${pkg['current_version']} → ${pkg['new_version']}'),
-                                dense: true,
-                              ))
-                          .toList(),
-                    ),
-                  ],
-                  if (status.newPackageCount > 0) ...[
-                    const SizedBox(height: 4),
-                    ExpansionTile(
-                      tilePadding: EdgeInsets.zero,
-                      title:
-                          Text('New Packages (${status.newPackageCount})'),
-                      children: status.newPackages
-                          .map((pkg) => ListTile(
-                                contentPadding: EdgeInsets.zero,
-                                title: Text(pkg['name']!),
-                                subtitle: Text('NEW · ${pkg['version']}'),
-                                dense: true,
-                              ))
-                          .toList(),
-                    ),
-                  ],
-                  // Install Update button
-                  if (status.updatesAvailable) ...[
-                    const SizedBox(height: 16),
-                    SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton.icon(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: theme.colorScheme.error,
-                          foregroundColor: theme.colorScheme.onError,
-                        ),
-                        icon: const Icon(Icons.system_update_alt),
-                        label: Text(
-                            '${l10n.installUpdate} (${status.totalPackageCount} packages)'),
-                        onPressed: () => _confirmAndUpdate(l10n, status),
-                      ),
-                    ),
-                  ],
+                ),
+              ],
+            ],
+            if (status.lastCheck.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text('Last checked: ${status.lastCheck}',
+                  style: theme.textTheme.bodySmall),
+            ],
+            // Changelog
+            if (status.changelogText != null) ...[
+              const SizedBox(height: 8),
+              ExpansionTile(
+                tilePadding: EdgeInsets.zero,
+                title: const Text("What's New"),
+                subtitle: status.changelogDate != null
+                    ? Text(status.changelogDate!)
+                    : null,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Text(status.changelogText!, softWrap: true),
+                  ),
                 ],
               ),
-            ),
+            ],
+            // Package lists
+            if (status.upgradeCount > 0) ...[
+              const SizedBox(height: 4),
+              ExpansionTile(
+                tilePadding: EdgeInsets.zero,
+                title: Text('Packages to Upgrade (${status.upgradeCount})'),
+                children: status.upgradePackages
+                    .map((pkg) => ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          title: Text(pkg['name']!),
+                          subtitle: Text(
+                              '${pkg['current_version']} → ${pkg['new_version']}'),
+                          dense: true,
+                        ))
+                    .toList(),
+              ),
+            ],
+            if (status.newPackageCount > 0) ...[
+              const SizedBox(height: 4),
+              ExpansionTile(
+                tilePadding: EdgeInsets.zero,
+                title: Text('New Packages (${status.newPackageCount})'),
+                children: status.newPackages
+                    .map((pkg) => ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          title: Text(pkg['name']!),
+                          subtitle: Text('NEW · ${pkg['version']}'),
+                          dense: true,
+                        ))
+                    .toList(),
+              ),
+            ],
+            // Install Update button
+            if (status.updatesAvailable) ...[
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: theme.colorScheme.error,
+                    foregroundColor: theme.colorScheme.onError,
+                  ),
+                  icon: const Icon(Icons.system_update_alt),
+                  label: Text(
+                      '${l10n.installUpdate} (${status.totalPackageCount} packages)'),
+                  onPressed: () => _confirmAndUpdate(l10n, status),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+
+    if (!hasLog) {
+      // No log: simple scrollable page.
+      return SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: summaryCard,
+      );
+    }
+
+    // Log present: summary scrolls in top half, log fills the rest.
+    return Column(
+      children: [
+        Flexible(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: summaryCard,
           ),
         ),
-        // Full check log below the summary card
-        if (_viewModel.checkLog?.isNotEmpty == true)
-          Expanded(
-            child: _buildLogView(title: 'Check output', isRunning: false),
-          ),
+        Expanded(
+          child: _buildLogView(title: 'Check output', isRunning: false),
+        ),
       ],
     );
   }
@@ -375,53 +394,64 @@ class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
 
   Widget _buildUpdateComplete(AppLocalizations l10n) {
     final theme = Theme.of(context);
+    final hasLog = _viewModel.checkLog?.isNotEmpty == true;
+
+    Widget completeCard = Card(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Icon(Icons.check_circle_outline,
+                size: 48, color: theme.colorScheme.primary),
+            const SizedBox(height: 12),
+            Text(
+              l10n.updateComplete,
+              style: theme.textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            if (_viewModel.updateRequiresReboot) ...[
+              const SizedBox(height: 8),
+              Text(l10n.rebootRequired,
+                  style: theme.textTheme.bodyMedium,
+                  textAlign: TextAlign.center),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: theme.colorScheme.error,
+                    foregroundColor: theme.colorScheme.onError,
+                  ),
+                  icon: const Icon(Icons.restart_alt),
+                  label: Text(l10n.rebootNow),
+                  onPressed: _rebootFirewall,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+
+    if (!hasLog) {
+      return SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: completeCard,
+      );
+    }
+
     return Column(
       children: [
-        Padding(
-          padding: const EdgeInsets.all(16),
-          child: Card(
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                children: [
-                  Icon(Icons.check_circle_outline,
-                      size: 48, color: theme.colorScheme.primary),
-                  const SizedBox(height: 12),
-                  Text(
-                    l10n.updateComplete,
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.center,
-                  ),
-                  if (_viewModel.updateRequiresReboot) ...[
-                    const SizedBox(height: 8),
-                    Text(l10n.rebootRequired,
-                        style: theme.textTheme.bodyMedium,
-                        textAlign: TextAlign.center),
-                    const SizedBox(height: 16),
-                    SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton.icon(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: theme.colorScheme.error,
-                          foregroundColor: theme.colorScheme.onError,
-                        ),
-                        icon: const Icon(Icons.restart_alt),
-                        label: Text(l10n.rebootNow),
-                        onPressed: _rebootFirewall,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
+        Flexible(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: completeCard,
           ),
         ),
-        // Install log remains visible after completion
-        if (_viewModel.checkLog?.isNotEmpty == true)
-          Expanded(
-            child: _buildLogView(title: 'Install output', isRunning: false),
-          ),
+        Expanded(
+          child: _buildLogView(title: 'Install output', isRunning: false),
+        ),
       ],
     );
   }

--- a/lib/screens/firmware_update_screen.dart
+++ b/lib/screens/firmware_update_screen.dart
@@ -22,7 +22,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../models/firmware_update_status.dart';
-import '../screens/dashboard_screen.dart';
 import '../services/demo_api_service.dart';
 import '../utils/single_init_mixin.dart';
 import '../utils/snackbar_helper.dart';
@@ -124,12 +123,15 @@ class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
 
     // Checking or installing — show live log terminal
     if (_viewModel.isChecking || _viewModel.isUpdating) {
-      return _buildLogView(
-        title: _viewModel.isUpdating
-            ? l10n.installingUpdate
-            : l10n.checkingForUpdates,
-        isRunning: true,
-      );
+      final String logTitle;
+      if (_viewModel.isExternalUpdateRunning) {
+        logTitle = 'Upgrade in progress…';
+      } else if (_viewModel.isUpdating) {
+        logTitle = l10n.installingUpdate;
+      } else {
+        logTitle = l10n.checkingForUpdates;
+      }
+      return _buildLogView(title: logTitle, isRunning: true);
     }
 
     // Error with no results
@@ -344,8 +346,9 @@ class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
                     .toList(),
               ),
             ],
-            // Install Update button
-            if (status.updatesAvailable) ...[
+            // Install Update button — hidden after an update just completed
+            // until the user runs a fresh check.
+            if (status.updatesAvailable && !_viewModel.updateJustCompleted) ...[
               const SizedBox(height: 16),
               SizedBox(
                 width: double.infinity,
@@ -411,23 +414,51 @@ class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
               textAlign: TextAlign.center,
             ),
             if (_viewModel.updateRequiresReboot) ...[
-              const SizedBox(height: 8),
-              Text(l10n.rebootRequired,
-                  style: theme.textTheme.bodyMedium,
-                  textAlign: TextAlign.center),
               const SizedBox(height: 16),
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton.icon(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: theme.colorScheme.error,
-                    foregroundColor: theme.colorScheme.onError,
-                  ),
-                  icon: const Icon(Icons.restart_alt),
-                  label: Text(l10n.rebootNow),
-                  onPressed: _rebootFirewall,
+              if (_viewModel.isBackOnline) ...[
+                // Firewall came back online.
+                Icon(Icons.wifi, color: theme.colorScheme.primary, size: 28),
+                const SizedBox(height: 8),
+                Text(
+                  'Firewall is back online.',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
                 ),
-              ),
+              ] else if (_viewModel.isWaitingForReboot) ...[
+                // Reboot in progress — waiting for it to come back.
+                const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Waiting for firewall to come back online…',
+                  style: theme.textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+              ] else ...[
+                // Reboot detected — waiting for it to fully shut down.
+                const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'System is rebooting…',
+                  style: theme.textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'The firewall will be unavailable for a minute.',
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  textAlign: TextAlign.center,
+                ),
+              ],
             ],
           ],
         ),
@@ -481,20 +512,4 @@ class _FirmwareUpdateScreenState extends State<FirmwareUpdateScreen>
     }
   }
 
-  Future<void> _rebootFirewall() async {
-    final apiService = context.read<DemoApiService>();
-    try {
-      await apiService.rebootSystem();
-    } catch (_) {
-      // Ignore — the firewall goes offline during reboot.
-    }
-    if (mounted) {
-      SnackBarHelper.showInfo(context, 'Rebooting firewall…');
-      unawaited(
-        Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (_) => const DashboardScreen()),
-        ),
-      );
-    }
-  }
 }

--- a/lib/screens/system_info_screen.dart
+++ b/lib/screens/system_info_screen.dart
@@ -16,9 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'firmware_update_screen.dart';
 import '../services/demo_api_service.dart';
 import '../utils/constants.dart';
 import '../utils/formatters.dart';
@@ -28,7 +28,7 @@ import '../widgets/app_drawer.dart';
 import '../widgets/common/error_display.dart';
 import '../l10n/app_localizations.dart';
 
-/// System information screen showing detailed system data
+/// System information screen showing detailed system data.
 class SystemInfoScreen extends StatefulWidget {
   const SystemInfoScreen({super.key});
 
@@ -109,21 +109,30 @@ class _SystemInfoScreenState extends State<SystemInfoScreen>
             if (systemInfo.commit.isNotEmpty)
               _buildInfoRow(Icons.commit, l10n.gitCommit, systemInfo.commit),
             if (systemInfo.mirror.isNotEmpty)
-              _buildInfoRow(
-                  Icons.cloud, l10n.packageMirror, systemInfo.mirror),
+              _buildInfoRow(Icons.cloud, l10n.packageMirror, systemInfo.mirror),
             if (systemInfo.repositories.isNotEmpty)
-              _buildInfoRow(
-                  Icons.source, l10n.repository, systemInfo.repositories),
-            if (systemInfo.updatedOn != null &&
-                systemInfo.updatedOn!.isNotEmpty)
-              _buildInfoRow(
-                  Icons.update, l10n.lastUpdate, systemInfo.updatedOn!),
+              _buildInfoRow(Icons.source, l10n.repository, systemInfo.repositories),
+            if (systemInfo.updatedOn != null && systemInfo.updatedOn!.isNotEmpty)
+              _buildInfoRow(Icons.update, l10n.lastUpdate, systemInfo.updatedOn!),
             _buildInfoRow(
               Icons.access_time,
               l10n.uptime,
               Formatters.formatUptime(systemInfo.uptime, context),
             ),
           ],
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            icon: const Icon(Icons.system_update_outlined),
+            label: Text(l10n.checkForUpdates),
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => const FirmwareUpdateScreen(),
+              ),
+            ),
+          ),
         ),
       ],
     );
@@ -171,7 +180,9 @@ class _SystemInfoScreenState extends State<SystemInfoScreen>
               children: [
                 Text(
                   label,
-                  style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                  style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant),
                 ),
                 const SizedBox(height: 2),
                 Text(

--- a/lib/services/demo_api_service.dart
+++ b/lib/services/demo_api_service.dart
@@ -1428,6 +1428,95 @@ ${List.generate(16, (i) => List.generate(32, (j) => '0123456789abcdef'[(i * 32 +
         delayMs: 500,
       );
 
+  // ==================== Firmware Updates ====================
+
+  /// Trigger a firmware update check
+  Future<Map<String, dynamic>> triggerFirmwareCheck() =>
+      DemoApiDecorator.execute<Map<String, dynamic>>(
+        isDemoMode: _isDemoMode,
+        demoAction: () async => {'status': 'ok', 'msg_uuid': 'demo-uuid-123'},
+        realAction: () => _realApiService.triggerFirmwareCheck(),
+        delayMs: 300,
+      );
+
+  /// Trigger the actual firmware update (POST /core/firmware/update).
+  /// The real API returns an empty body; demo returns {} immediately.
+  Future<Map<String, dynamic>> triggerFirmwareUpdate() =>
+      DemoApiDecorator.execute<Map<String, dynamic>>(
+        isDemoMode: _isDemoMode,
+        demoAction: () async => <String, dynamic>{},
+        realAction: () => _realApiService.triggerFirmwareUpdate(),
+      );
+
+  /// Get firmware upgrade/check status (polling endpoint)
+  Future<Map<String, dynamic>> getFirmwareUpgradeStatus() =>
+      DemoApiDecorator.execute<Map<String, dynamic>>(
+        isDemoMode: _isDemoMode,
+        demoAction: () async =>
+            {'status': 'done', 'log': 'Demo check complete.\n***DONE***'},
+        realAction: () => _realApiService.getFirmwareUpgradeStatus(),
+        delayMs: 200,
+      );
+
+  /// Get current firmware status (available updates, packages, etc.)
+  Future<Map<String, dynamic>> getFirmwareStatus() =>
+      DemoApiDecorator.execute<Map<String, dynamic>>(
+        isDemoMode: _isDemoMode,
+        demoAction: () async => {
+          'needs_reboot': '1',
+          'download_size': '45MiB',
+          'last_check': 'Thu Jan 1 00:00:00 UTC 2026',
+          'new_packages': [
+            {
+              'name': 'cpu-microcode-rc',
+              'repository': 'OPNsense',
+              'version': '1.0_2',
+            },
+          ],
+          'upgrade_packages': [
+            {
+              'name': 'opnsense',
+              'repository': 'OPNsense',
+              'current_version': '26.7',
+              'new_version': '26.7.3',
+            },
+            {
+              'name': 'openssh-portable',
+              'repository': 'OPNsense',
+              'current_version': '10.3.p1,1',
+              'new_version': '10.5.p1_1,1',
+            },
+            {
+              'name': 'openssl35',
+              'repository': 'OPNsense',
+              'current_version': '3.5.7',
+              'new_version': '3.5.8',
+            },
+          ],
+          'product': {
+            'product_version': '26.7',
+            'product_latest': '26.7.3',
+          },
+        },
+        realAction: () => _realApiService.getFirmwareStatus(),
+        delayMs: 400,
+      );
+
+  /// Get firmware changelog for a given version
+  Future<Map<String, dynamic>> getFirmwareChangelog(String version) =>
+      DemoApiDecorator.execute<Map<String, dynamic>>(
+        isDemoMode: _isDemoMode,
+        demoAction: () async => {
+          'status': 'ok',
+          'version': version,
+          'html':
+              '<p>Demo changelog for OPNsense $version. This update includes security fixes and performance improvements.</p>',
+          'date': 'January 1, 2026',
+        },
+        realAction: () => _realApiService.getFirmwareChangelog(version),
+        delayMs: 300,
+      );
+
   /// Clear service state
   void clear() {
     _demoDataService.reset();

--- a/lib/services/opnsense_api_service.dart
+++ b/lib/services/opnsense_api_service.dart
@@ -221,6 +221,11 @@ class OPNsenseApiService {
   Future<List<ThermalSensor>> getSystemTemperature() => _systemService.getSystemTemperature();
   
   Future<void> rebootSystem() => _systemService.rebootSystem();
+  Future<Map<String, dynamic>> triggerFirmwareCheck() => _systemService.triggerFirmwareCheck();
+  Future<Map<String, dynamic>> triggerFirmwareUpdate() => _systemService.triggerFirmwareUpdate();
+  Future<Map<String, dynamic>> getFirmwareUpgradeStatus() => _systemService.getFirmwareUpgradeStatus();
+  Future<Map<String, dynamic>> getFirmwareStatus() => _systemService.getFirmwareStatus();
+  Future<Map<String, dynamic>> getFirmwareChangelog(String version) => _systemService.getFirmwareChangelog(version);
 
   // ============================================================================
   // Firewall Service Delegations

--- a/lib/services/system/system_service.dart
+++ b/lib/services/system/system_service.dart
@@ -425,6 +425,105 @@ class SystemService extends BaseOPNsenseService {
       throw handleDioError(e);
     }
   }
+
+  /// Trigger a firmware update check (POST /core/firmware/check).
+  /// Returns a map containing `msg_uuid` and `status`.
+  Future<Map<String, dynamic>> triggerFirmwareCheck() async {
+    ensureInitialized();
+
+    try {
+      final response = await dio.post(ApiEndpoints.firmwareCheck, data: {});
+
+      if (response.statusCode == 200) {
+        return response.data as Map<String, dynamic>;
+      } else {
+        throw ApiException('Failed to trigger firmware check', response.statusCode, ApiErrorType.unknown);
+      }
+    } on DioException catch (e) {
+      throw handleDioError(e);
+    }
+  }
+
+  /// Poll firmware upgrade status (GET /core/firmware/upgradestatus).
+  /// A cache-busting query param is appended to prevent stale responses.
+  /// Returns a map containing `status` and `log`.
+  Future<Map<String, dynamic>> getFirmwareUpgradeStatus() async {
+    ensureInitialized();
+
+    try {
+      final ts = DateTime.now().millisecondsSinceEpoch;
+      final response = await dio.get(
+        ApiEndpoints.firmwareUpgradeStatus,
+        queryParameters: {'v': ts},
+      );
+
+      if (response.statusCode == 200) {
+        return response.data as Map<String, dynamic>;
+      } else {
+        throw ApiException('Failed to get firmware upgrade status', response.statusCode, ApiErrorType.unknown);
+      }
+    } on DioException catch (e) {
+      throw handleDioError(e);
+    }
+  }
+
+  /// Get the current firmware status (GET /core/firmware/status).
+  /// Returns the full status payload including `product`, `upgrade_packages`, etc.
+  Future<Map<String, dynamic>> getFirmwareStatus() async {
+    ensureInitialized();
+
+    try {
+      final response = await dio.get(ApiEndpoints.firmwareStatus);
+
+      if (response.statusCode == 200) {
+        return response.data as Map<String, dynamic>;
+      } else {
+        throw ApiException('Failed to get firmware status', response.statusCode, ApiErrorType.unknown);
+      }
+    } on DioException catch (e) {
+      throw handleDioError(e);
+    }
+  }
+
+  /// Fetch the changelog for a specific firmware [version]
+  /// (POST /core/firmware/changelog/{version}).
+  /// Returns a map containing `html`, `version`, and `date`.
+  Future<Map<String, dynamic>> getFirmwareChangelog(String version) async {
+    ensureInitialized();
+
+    try {
+      final response = await dio.post(ApiEndpoints.firmwareChangelog(version), data: {});
+
+      if (response.statusCode == 200) {
+        return response.data as Map<String, dynamic>;
+      } else {
+        throw ApiException('Failed to get firmware changelog', response.statusCode, ApiErrorType.unknown);
+      }
+    } on DioException catch (e) {
+      throw handleDioError(e);
+    }
+  }
+
+  /// Trigger a firmware update (POST /core/firmware/update).
+  /// The real API returns an empty body — the empty-map fallback handles that.
+  Future<Map<String, dynamic>> triggerFirmwareUpdate() async {
+    ensureInitialized();
+
+    try {
+      final response = await dio.post(ApiEndpoints.firmwareUpdate, data: {});
+
+      if (response.statusCode == 200) {
+        return response.data is Map
+            ? response.data as Map<String, dynamic>
+            : <String, dynamic>{};
+      } else {
+        throw ApiException(
+            'Failed to trigger firmware update', response.statusCode, ApiErrorType.unknown);
+      }
+    } on DioException catch (e) {
+      throw handleDioError(e);
+    }
+  }
 }
 
 

--- a/lib/viewmodels/firmware_update_view_model.dart
+++ b/lib/viewmodels/firmware_update_view_model.dart
@@ -1,0 +1,219 @@
+/*
+ * OPNsense Manager - Flutter application for managing OPNsense firewalls
+ * Copyright (C) 2026 OPNsense Manager
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import '../models/firmware_update_status.dart';
+import '../services/demo_api_service.dart';
+import 'base/base_form_view_model.dart';
+
+/// ViewModel for the Firmware Update screen.
+///
+/// Orchestrates the check-for-updates and perform-update flows:
+///
+/// Check flow:
+/// 1. Trigger the check via `/api/core/firmware/check`.
+/// 2. Poll `/api/core/firmware/upgradestatus` until `status == "done"`.
+/// 3. Fetch the full status and optional changelog.
+///
+/// Update flow:
+/// 1. Trigger the update via `/api/core/firmware/update`.
+/// 2. Poll `/api/core/firmware/upgradestatus` until `status == "reboot"`.
+class FirmwareUpdateViewModel extends BaseFormViewModel {
+  final DemoApiService _apiService;
+
+  FirmwareUpdateStatus? _firmwareStatus;
+  String? _checkLog;
+  bool _isChecking = false;
+  bool _isUpdating = false;
+  bool _updateRequiresReboot = false;
+  bool _isUpdateComplete = false;
+  bool _cancelled = false;
+
+  FirmwareUpdateStatus? get firmwareStatus => _firmwareStatus;
+  String? get checkLog => _checkLog;
+  bool get isChecking => _isChecking;
+  bool get isUpdating => _isUpdating;
+  bool get updateRequiresReboot => _updateRequiresReboot;
+  bool get isUpdateComplete => _isUpdateComplete;
+
+  FirmwareUpdateViewModel(this._apiService);
+
+  Future<void> checkForUpdates() async {
+    _cancelled = false;
+    _firmwareStatus = null;
+    _checkLog = null;
+    _isChecking = true;
+    setLoading(true);
+    clearError();
+
+    try {
+      // Step 1: Trigger the firmware check.
+      final checkResult = await _apiService.triggerFirmwareCheck();
+      if (checkResult['status'] != 'ok') {
+        throw Exception('Firmware check failed: ${checkResult['status']}');
+      }
+
+      // Step 2: Poll upgradestatus until done (max 30 iterations ≈ 45 s).
+      const maxPolls = 30;
+      int polls = 0;
+      while (polls < maxPolls) {
+        if (_cancelled) return;
+        final statusResult = await _apiService.getFirmwareUpgradeStatus();
+        _checkLog = statusResult['log'] as String? ?? '';
+        notifyListeners();
+        if (statusResult['status'] == 'done') break;
+        polls++;
+        if (polls >= maxPolls) throw Exception('Firmware check timed out');
+        await Future.delayed(const Duration(milliseconds: 1500));
+      }
+
+      if (_cancelled) return;
+
+      // Step 3: Fetch the full firmware status.
+      final statusData = await _apiService.getFirmwareStatus();
+      if (_cancelled) return;
+
+      final product = statusData['product'] as Map<String, dynamic>? ?? {};
+      final currentVersion = product['product_version'] as String? ?? '';
+      final latestVersion =
+          product['product_latest'] as String? ?? currentVersion;
+
+      final rawUpgrade = statusData['upgrade_packages'] as List? ?? [];
+      final upgradePackages = rawUpgrade.map((e) {
+        final m = e as Map<String, dynamic>;
+        return <String, String>{
+          'name': m['name'] as String? ?? '',
+          'current_version': m['current_version'] as String? ?? '',
+          'new_version': m['new_version'] as String? ?? '',
+        };
+      }).toList();
+
+      final rawNew = statusData['new_packages'] as List? ?? [];
+      final newPackages = rawNew.map((e) {
+        final m = e as Map<String, dynamic>;
+        return <String, String>{
+          'name': m['name'] as String? ?? '',
+          'version': m['version'] as String? ?? '',
+        };
+      }).toList();
+
+      final needsReboot = statusData['needs_reboot'] == '1';
+      final downloadSize = statusData['download_size'] as String? ?? '';
+      final lastCheck = statusData['last_check'] as String? ?? '';
+
+      // Step 4: Fetch changelog when updates are available (optional).
+      String? changelogText;
+      String? changelogDate;
+      if (upgradePackages.isNotEmpty || newPackages.isNotEmpty) {
+        if (_cancelled) return;
+        try {
+          final changelogData =
+              await _apiService.getFirmwareChangelog(latestVersion);
+          final html = changelogData['html'] as String? ?? '';
+          changelogText = html.replaceAll(RegExp(r'<[^>]*>'), '').trim();
+          changelogDate = changelogData['date'] as String?;
+        } catch (_) {
+          // Changelog is optional — ignore failures.
+        }
+      }
+
+      if (_cancelled) return;
+
+      _firmwareStatus = FirmwareUpdateStatus(
+        currentVersion: currentVersion,
+        latestVersion: latestVersion,
+        updatesAvailable:
+            upgradePackages.isNotEmpty || newPackages.isNotEmpty,
+        needsReboot: needsReboot,
+        downloadSize: downloadSize,
+        lastCheck: lastCheck,
+        upgradeCount: upgradePackages.length,
+        newPackageCount: newPackages.length,
+        upgradePackages: upgradePackages,
+        newPackages: newPackages,
+        changelogText: changelogText,
+        changelogDate: changelogDate,
+      );
+    } catch (e) {
+      if (!_cancelled) setError(e.toString());
+    } finally {
+      if (!_cancelled) {
+        _isChecking = false;
+        setLoading(false);
+      }
+    }
+  }
+
+  /// Perform the actual firmware upgrade.
+  ///
+  /// Flow:
+  /// 1. POST `/api/core/firmware/update` to trigger the upgrade.
+  /// 2. Poll `/api/core/firmware/upgradestatus` every 1.5 s until
+  ///    `status == "reboot"` (or `"done"`), with a 300-iteration timeout
+  ///    (≈ 7.5 min) to accommodate large updates.
+  Future<void> performUpdate() async {
+    _cancelled = false;
+    _isUpdating = true;
+    _updateRequiresReboot = false;
+    _isUpdateComplete = false;
+    _checkLog = null;
+    setLoading(true);
+    clearError();
+
+    try {
+      // Step 1: Trigger the firmware update.
+      await _apiService.triggerFirmwareUpdate();
+
+      // Step 2: Poll upgradestatus until terminal state (max 300 ≈ 7.5 min).
+      const maxPolls = 300;
+      int polls = 0;
+      while (polls < maxPolls) {
+        if (_cancelled) return;
+        final statusResult = await _apiService.getFirmwareUpgradeStatus();
+        _checkLog = statusResult['log'] as String? ?? '';
+        notifyListeners();
+
+        final status = statusResult['status'] as String? ?? '';
+        if (status == 'reboot') {
+          if (!_cancelled) _updateRequiresReboot = true;
+          break;
+        }
+        if (status == 'done') break;
+
+        polls++;
+        if (polls >= maxPolls) throw Exception('Firmware update timed out');
+        await Future.delayed(const Duration(milliseconds: 1500));
+      }
+
+      if (_cancelled) return;
+      _isUpdateComplete = true;
+    } catch (e) {
+      if (!_cancelled) setError(e.toString());
+    } finally {
+      if (!_cancelled) {
+        _isUpdating = false;
+        setLoading(false);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _cancelled = true;
+    super.dispose();
+  }
+}

--- a/lib/viewmodels/firmware_update_view_model.dart
+++ b/lib/viewmodels/firmware_update_view_model.dart
@@ -16,7 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import 'dart:async';
+
 import '../models/firmware_update_status.dart';
+import '../services/base/api_exception.dart';
 import '../services/demo_api_service.dart';
 import 'base/base_form_view_model.dart';
 
@@ -27,11 +30,15 @@ import 'base/base_form_view_model.dart';
 /// Check flow:
 /// 1. Trigger the check via `/api/core/firmware/check`.
 /// 2. Poll `/api/core/firmware/upgradestatus` until `status == "done"`.
+///    If `status == "running"` is detected (an upgrade was already in progress),
+///    transparently switch into watch mode and wait for it to complete.
 /// 3. Fetch the full status and optional changelog.
 ///
 /// Update flow:
 /// 1. Trigger the update via `/api/core/firmware/update`.
-/// 2. Poll `/api/core/firmware/upgradestatus` until `status == "reboot"`.
+/// 2. Poll `/api/core/firmware/upgradestatus` every 500 ms until
+///    `status == "reboot"` or `"done"`, with a 900-iteration timeout
+///    (≈ 7.5 min) to accommodate large updates.
 class FirmwareUpdateViewModel extends BaseFormViewModel {
   final DemoApiService _apiService;
 
@@ -39,16 +46,30 @@ class FirmwareUpdateViewModel extends BaseFormViewModel {
   String? _checkLog;
   bool _isChecking = false;
   bool _isUpdating = false;
+  bool _isExternalUpdateRunning = false;
   bool _updateRequiresReboot = false;
   bool _isUpdateComplete = false;
+  // Set to true after a successful performUpdate(); cleared by checkForUpdates().
+  // Suppresses the "Install Updates" button until a fresh check is run.
+  bool _updateJustCompleted = false;
+  bool _isWaitingForReboot = false;
+  bool _isBackOnline = false;
   bool _cancelled = false;
 
   FirmwareUpdateStatus? get firmwareStatus => _firmwareStatus;
   String? get checkLog => _checkLog;
   bool get isChecking => _isChecking;
   bool get isUpdating => _isUpdating;
+  /// True when checkForUpdates() discovered an already-running upgrade and
+  /// switched into watch mode. Used to display the correct log title.
+  bool get isExternalUpdateRunning => _isExternalUpdateRunning;
   bool get updateRequiresReboot => _updateRequiresReboot;
   bool get isUpdateComplete => _isUpdateComplete;
+  bool get updateJustCompleted => _updateJustCompleted;
+  /// True while polling for the firewall to come back after a reboot.
+  bool get isWaitingForReboot => _isWaitingForReboot;
+  /// True once the firewall responds successfully after a reboot.
+  bool get isBackOnline => _isBackOnline;
 
   FirmwareUpdateViewModel(this._apiService);
 
@@ -57,6 +78,11 @@ class FirmwareUpdateViewModel extends BaseFormViewModel {
     _firmwareStatus = null;
     _checkLog = null;
     _isChecking = true;
+    _isExternalUpdateRunning = false;
+    _updateJustCompleted = false;
+    _isUpdateComplete = false;
+    _isWaitingForReboot = false;
+    _isBackOnline = false;
     setLoading(true);
     clearError();
 
@@ -67,21 +93,108 @@ class FirmwareUpdateViewModel extends BaseFormViewModel {
         throw Exception('Firmware check failed: ${checkResult['status']}');
       }
 
-      // Step 2: Poll upgradestatus until done (max 30 iterations ≈ 45 s).
-      const maxPolls = 30;
+      // Step 2: Poll upgradestatus until done.
+      //
+      // OPNsense status values during a normal check:   running → done  (<10 s)
+      // OPNsense status values during an active upgrade: running → reboot
+      //
+      // A normal check completes well within 15 s. If "running" persists
+      // beyond maxCheckPolls (10 × 1.5 s ≈ 15 s) without reaching "done",
+      // an upgrade was already in flight — switch to watch mode instead of
+      // timing out. A real network failure throws an exception, not a response.
+      const maxCheckPolls = 10;
       int polls = 0;
-      while (polls < maxPolls) {
+      bool checkExhausted = false;
+      while (polls < maxCheckPolls) {
         if (_cancelled) return;
         final statusResult = await _apiService.getFirmwareUpgradeStatus();
         _checkLog = statusResult['log'] as String? ?? '';
         notifyListeners();
-        if (statusResult['status'] == 'done') break;
+
+        final status = statusResult['status'] as String? ?? '';
+
+        if (status == 'done') break;
+        if (status == 'reboot') {
+          // Unexpected during a check — treat as external upgrade completing.
+          _updateRequiresReboot = true;
+          checkExhausted = true;
+          break;
+        }
+
         polls++;
-        if (polls >= maxPolls) throw Exception('Firmware check timed out');
+        if (polls >= maxCheckPolls) {
+          // Still "running" after ~15 s — an upgrade must already be running.
+          // Switch to watch mode below.
+          checkExhausted = true;
+          break;
+        }
         await Future.delayed(const Duration(milliseconds: 1500));
       }
 
+      // Still "running" after the check window — watch the active upgrade.
+      if (checkExhausted && !_cancelled) {
+        _isExternalUpdateRunning = true;
+        _isChecking = false;
+        _isUpdating = true;
+        notifyListeners();
+
+        // Poll until the upgrade reaches a terminal state — no iteration cap.
+        while (true) {
+          if (_cancelled) return;
+          try {
+            final statusResult = await _apiService.getFirmwareUpgradeStatus();
+            _checkLog = statusResult['log'] as String? ?? '';
+            notifyListeners();
+
+            final status = statusResult['status'] as String? ?? '';
+            final logIndicatesReboot = _checkLog?.contains('***REBOOT***') ?? false;
+
+            if (status == 'reboot' || logIndicatesReboot) {
+              _updateRequiresReboot = true;
+              break;
+            }
+            if (status == 'done') break;
+          } on ApiException catch (e) {
+            if (e.errorType == ApiErrorType.networkError) {
+              // Connection dropped mid-upgrade. Only treat as a reboot if the
+              // log already contains the reboot marker — otherwise it is a
+              // transient web-server restart during package extraction; retry.
+              if (_checkLog?.contains('***REBOOT***') ?? false) {
+                _updateRequiresReboot = true;
+                break;
+              }
+              await Future.delayed(const Duration(milliseconds: 1500));
+              continue;
+            }
+            rethrow;
+          }
+          await Future.delayed(const Duration(milliseconds: 500));
+        }
+      }
+
+      // Drain final log snapshot so the last lines are never missed.
+      // If the system already rebooted, this call may fail with a connection
+      // error — ignore it and keep whatever log we already have.
+      if (!_cancelled) {
+        try {
+          final finalStatus = await _apiService.getFirmwareUpgradeStatus();
+          _checkLog = finalStatus['log'] as String? ?? _checkLog;
+          notifyListeners();
+        } on ApiException catch (e) {
+          if (e.errorType != ApiErrorType.networkError) rethrow;
+        }
+      }
+
       if (_cancelled) return;
+
+      // If we were watching an external update, finish as update-complete.
+      if (_isExternalUpdateRunning) {
+        _isUpdateComplete = true;
+        if (_updateRequiresReboot) {
+          unawaited(_waitForFirewallOnline());
+        }
+        return;
+      }
 
       // Step 3: Fetch the full firmware status.
       final statusData = await _apiService.getFirmwareStatus();
@@ -153,6 +266,8 @@ class FirmwareUpdateViewModel extends BaseFormViewModel {
     } finally {
       if (!_cancelled) {
         _isChecking = false;
+        // isUpdating may have been set in watch mode — clear it here too.
+        _isUpdating = false;
         setLoading(false);
       }
     }
@@ -162,12 +277,13 @@ class FirmwareUpdateViewModel extends BaseFormViewModel {
   ///
   /// Flow:
   /// 1. POST `/api/core/firmware/update` to trigger the upgrade.
-  /// 2. Poll `/api/core/firmware/upgradestatus` every 1.5 s until
-  ///    `status == "reboot"` (or `"done"`), with a 300-iteration timeout
+  /// 2. Poll `/api/core/firmware/upgradestatus` every 500 ms until
+  ///    `status == "reboot"` (or `"done"`), with a 900-iteration timeout
   ///    (≈ 7.5 min) to accommodate large updates.
   Future<void> performUpdate() async {
     _cancelled = false;
     _isUpdating = true;
+    _isExternalUpdateRunning = false;
     _updateRequiresReboot = false;
     _isUpdateComplete = false;
     _checkLog = null;
@@ -178,29 +294,67 @@ class FirmwareUpdateViewModel extends BaseFormViewModel {
       // Step 1: Trigger the firmware update.
       await _apiService.triggerFirmwareUpdate();
 
-      // Step 2: Poll upgradestatus until terminal state (max 300 ≈ 7.5 min).
-      const maxPolls = 300;
+      // Step 2: Poll upgradestatus until terminal state (max 900 × 500 ms ≈ 7.5 min).
+      // Terminal conditions (either is sufficient):
+      //   • API status field == "reboot" or "done"
+      //   • Log text contains "***REBOOT***" (reliable even if the status
+      //     field flips back before the next poll)
+      const maxPolls = 900;
       int polls = 0;
       while (polls < maxPolls) {
         if (_cancelled) return;
-        final statusResult = await _apiService.getFirmwareUpgradeStatus();
-        _checkLog = statusResult['log'] as String? ?? '';
-        notifyListeners();
+        try {
+          final statusResult = await _apiService.getFirmwareUpgradeStatus();
+          _checkLog = statusResult['log'] as String? ?? '';
+          notifyListeners();
 
-        final status = statusResult['status'] as String? ?? '';
-        if (status == 'reboot') {
-          if (!_cancelled) _updateRequiresReboot = true;
-          break;
+          final status = statusResult['status'] as String? ?? '';
+          final logIndicatesReboot = _checkLog?.contains('***REBOOT***') ?? false;
+
+          if (status == 'reboot' || logIndicatesReboot) {
+            _updateRequiresReboot = true;
+            break;
+          }
+          if (status == 'done') break;
+        } on ApiException catch (e) {
+          if (e.errorType == ApiErrorType.networkError) {
+            // Connection dropped mid-upgrade. Only treat as a reboot if the
+            // log already contains the reboot marker — otherwise it is a
+            // transient web-server restart during package extraction; retry.
+            if (_checkLog?.contains('***REBOOT***') ?? false) {
+              _updateRequiresReboot = true;
+              break;
+            }
+            await Future.delayed(const Duration(milliseconds: 1500));
+            continue;
+          }
+          rethrow;
         }
-        if (status == 'done') break;
 
         polls++;
         if (polls >= maxPolls) throw Exception('Firmware update timed out');
-        await Future.delayed(const Duration(milliseconds: 1500));
+        await Future.delayed(const Duration(milliseconds: 500));
+      }
+
+      // Drain final log snapshot to capture the last lines (e.g. "Rebooting now").
+      // Ignore connection errors — the firewall may already be going down.
+      if (!_cancelled) {
+        try {
+          final finalStatus = await _apiService.getFirmwareUpgradeStatus();
+          _checkLog = finalStatus['log'] as String? ?? _checkLog;
+          notifyListeners();
+        } on ApiException catch (e) {
+          if (e.errorType != ApiErrorType.networkError) rethrow;
+        }
       }
 
       if (_cancelled) return;
       _isUpdateComplete = true;
+      _updateJustCompleted = true;
+      // If a reboot was triggered, start polling for the firewall to come back.
+      if (_updateRequiresReboot) {
+        unawaited(_waitForFirewallOnline());
+      }
     } catch (e) {
       if (!_cancelled) setError(e.toString());
     } finally {
@@ -208,6 +362,45 @@ class FirmwareUpdateViewModel extends BaseFormViewModel {
         _isUpdating = false;
         setLoading(false);
       }
+    }
+  }
+
+  /// Polls `getFirmwareStatus` until the firewall responds, indicating it has
+  /// come back online after a reboot. Updates [isWaitingForReboot] and
+  /// [isBackOnline] so the UI can reflect each phase.
+  Future<void> _waitForFirewallOnline() async {
+    _isWaitingForReboot = true;
+    notifyListeners();
+
+    // Wait a minimum of 15 s before the first probe — the firewall needs time
+    // to fully shut down before we start polling.
+    await Future.delayed(const Duration(seconds: 15));
+
+    while (!_cancelled) {
+      try {
+        await _apiService.getFirmwareStatus();
+        // Got a valid response — firewall is back.
+        if (!_cancelled) {
+          _isWaitingForReboot = false;
+          _isBackOnline = true;
+          notifyListeners();
+        }
+        return;
+      } on ApiException catch (e) {
+        // Any network/connection error means still offline — keep polling.
+        if (e.errorType != ApiErrorType.networkError &&
+            e.errorType != ApiErrorType.timeout) {
+          // Unexpected error type — stop waiting silently.
+          if (!_cancelled) {
+            _isWaitingForReboot = false;
+            notifyListeners();
+          }
+          return;
+        }
+      } catch (_) {
+        // Swallow any other error and keep trying.
+      }
+      await Future.delayed(const Duration(seconds: 5));
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a Firmware Update screen that allows users to check for available OPNsense firmware updates, view current and latest versions, and install updates directly from the app. The screen shows a live log terminal during an update and handles mid-run reboot prompts. It also detects in-progress upgrades on app launch and attaches to the running log stream.

## Changes

- Added `FirmwareUpdateScreen` with live log terminal, version comparison, and install controls
- Added `FirmwareUpdateViewModel` with reboot polling, external upgrade watch mode, and update state tracking
- Added `FirmwareUpdateStatus` model for firmware API response parsing
- Added `SystemService` with firmware status, initiate upgrade, and upgrade log API methods
- Added firmware update API endpoints to `api_endpoints.dart`
- Added demo service stubs for firmware update in `DemoApiService`
- Added entry point to firmware update screen from `SystemInfoScreen`
- Added l10n strings for all firmware update labels across en, ar, de, es, fr locales
- Updated `CHANGELOG.md` with firmware update feature details for v1.8.0